### PR TITLE
Correct Atlassian AMI IDs

### DIFF
--- a/templates/BitbucketDataCenter-EC2NFS.template
+++ b/templates/BitbucketDataCenter-EC2NFS.template
@@ -687,52 +687,48 @@
       }
     },
     "AWSRegionArch2AMI": {
-      "us-east-1": {
-        "HVM64": "ami-2bba203c",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "us-west-1": {
-        "HVM64": "ami-d1094bb1",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "us-west-2": {
-        "HVM64": "ami-3b30fa5b",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "eu-west-1": {
-        "HVM64": "ami-63a3d610",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "eu-central-1": {
-        "HVM64": "ami-13a4557c",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "ap-northeast-1": {
-        "HVM64": "ami-d728eab6",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "ap-northeast-2": {
-        "HVM64": "ami-426fa52c",
+      "ap-southeast-2": {
+        "HVM64": "ami-7fe4d31c",
         "HVMG2": "NOT_SUPPORTED"
       },
       "ap-south-1": {
-        "HVM64": "ami-9f7207f0",
+        "HVM64": "ami-b25c29dd",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "eu-west-1": {
+        "HVM64": "ami-e6e89f95",
         "HVMG2": "NOT_SUPPORTED"
       },
       "ap-southeast-1": {
-        "HVM64": "ami-f6f32a95",
+        "HVM64": "ami-819149e2",
         "HVMG2": "NOT_SUPPORTED"
       },
-      "ap-southeast-2": {
-        "HVM64": "ami-f5734496",
+      "eu-central-1": {
+        "HVM64": "ami-847584eb",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "ap-northeast-2": {
+        "HVM64": "ami-a3895ccd",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "ap-northeast-1": {
+        "HVM64": "ami-65925d04",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "us-east-1": {
+        "HVM64": "ami-98d9bf8f",
         "HVMG2": "NOT_SUPPORTED"
       },
       "sa-east-1": {
-        "HVM64": "ami-cd65f3a1",
+        "HVM64": "ami-95fd6cf9",
         "HVMG2": "NOT_SUPPORTED"
       },
-      "cn-north-1": {
-        "HVM64": "NOT_SUPPORTED",
+      "us-west-1": {
+        "HVM64": "ami-1ea8ea7e",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "us-west-2": {
+        "HVM64": "ami-92d602f2",
         "HVMG2": "NOT_SUPPORTED"
       }
     }

--- a/templates/BitbucketDataCenter.template
+++ b/templates/BitbucketDataCenter.template
@@ -9,7 +9,7 @@
             "default": "Bitbucket Setup"
           },
           "Parameters": [
-            "BitbucketVersion",
+            "BitbucketVersion"
           ]
         },
         {
@@ -509,52 +509,48 @@
       }
     },
     "AWSRegionArch2AMI": {
-      "us-east-1": {
-        "HVM64": "ami-2bba203c",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "us-west-1": {
-        "HVM64": "ami-d1094bb1",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "us-west-2": {
-        "HVM64": "ami-3b30fa5b",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "eu-west-1": {
-        "HVM64": "ami-63a3d610",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "eu-central-1": {
-        "HVM64": "ami-13a4557c",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "ap-northeast-1": {
-        "HVM64": "ami-d728eab6",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "ap-northeast-2": {
-        "HVM64": "ami-426fa52c",
+      "ap-southeast-2": {
+        "HVM64": "ami-7fe4d31c",
         "HVMG2": "NOT_SUPPORTED"
       },
       "ap-south-1": {
-        "HVM64": "ami-9f7207f0",
+        "HVM64": "ami-b25c29dd",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "eu-west-1": {
+        "HVM64": "ami-e6e89f95",
         "HVMG2": "NOT_SUPPORTED"
       },
       "ap-southeast-1": {
-        "HVM64": "ami-f6f32a95",
+        "HVM64": "ami-819149e2",
         "HVMG2": "NOT_SUPPORTED"
       },
-      "ap-southeast-2": {
-        "HVM64": "ami-f5734496",
+      "eu-central-1": {
+        "HVM64": "ami-847584eb",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "ap-northeast-2": {
+        "HVM64": "ami-a3895ccd",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "ap-northeast-1": {
+        "HVM64": "ami-65925d04",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "us-east-1": {
+        "HVM64": "ami-98d9bf8f",
         "HVMG2": "NOT_SUPPORTED"
       },
       "sa-east-1": {
-        "HVM64": "ami-cd65f3a1",
+        "HVM64": "ami-95fd6cf9",
         "HVMG2": "NOT_SUPPORTED"
       },
-      "cn-north-1": {
-        "HVM64": "NOT_SUPPORTED",
+      "us-west-1": {
+        "HVM64": "ami-1ea8ea7e",
+        "HVMG2": "NOT_SUPPORTED"
+      },
+      "us-west-2": {
+        "HVM64": "ami-92d602f2",
         "HVMG2": "NOT_SUPPORTED"
       }
     }


### PR DESCRIPTION
This pull request has the correct AMI IDs that Atlassian are using. For the moment test this only in the us-east-1 region. The below accounts have been given permission for these AMIs

860521661824
536065598225
