### PR TITLE
Update `BitbucketDataCenter.template`

### DIFF
--- a/templates/BitbucketDataCenter.template
+++ b/templates/BitbucketDataCenter.template
@@ -1,2181 +1,1125 @@
-{
-  "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "QS(0034) Atlassian Bitbucket Data Center Oct,6,2016",
-  "Metadata": {
-    "AWS::CloudFormation::Interface": {
-      "ParameterGroups": [
-        {
-          "Label": {
-            "default": "Bitbucket setup"
-          },
-          "Parameters": [
-            "BitbucketVersion"
-          ]
-        },
-        {
-          "Label": {
-            "default": "Cluster nodes"
-          },
-          "Parameters": [
-            "ClusterNodeInstanceType",
-            "ClusterNodeMin",
-            "ClusterNodeMax"
-          ]
-        },
-        {
-          "Label": {
-            "default": "File server"
-          },
-          "Parameters": [
-            "FileServerInstanceType",
-            "HomeSize",
-            "HomeVolumeType",
-            "HomeIops"
-          ]
-        },
-        {
-          "Label": {
-            "default": "Database"
-          },
-          "Parameters": [
-            "DBInstanceClass",
-            "DBMasterUserPassword",
-            "DBPassword",
-            "DBStorage",
-            "DBStorageType",
-            "DBIops",
-            "DBMultiAZ"
-          ]
-        },
-        {
-          "Label": {
-            "default": "Elasticsearch"
-          },
-          "Parameters": [
-            "ElasticsearchInstanceType"
-          ]
-        },
-        {
-          "Label": {
-            "default": "Networking"
-          },
-          "Parameters": [
-            "VPC",
-            "ExternalSubnets",
-            "InternalSubnets",
-            "AssociatePublicIpAddress",
-            "CidrBlock",
-            "KeyName",
-            "SSLCertificateName"
-          ]
-        },
-        {
-          "Label": {
-            "default": "Advanced (Optional)"
-          },
-          "Parameters": [
-            "DBSnapshotId",
-            "HomeVolumeSnapshotId",
-            "BitbucketProperties",
-            "CatalinaOpts",
-            "HomeDeleteOnTermination",
-            "DBMaster",
-            "StartCollectd"
-          ]
-        }
-      ],
-      "ParameterLabels": {
-        "AssociatePublicIpAddress": {
-          "default": "Assign public IP"
-        },
-        "BitbucketProperties": {
-          "default": "Bitbucket properties"
-        },
-        "BitbucketVersion": {
-          "default": "Version *"
-        },
-        "CatalinaOpts": {
-          "default": "Catalina options"
-        },
-        "CidrBlock": {
-          "default": "Permitted IP range *"
-        },
-        "ClusterNodeMax": {
-          "default": "Maximum number of cluster nodes"
-        },
-        "ClusterNodeMin": {
-          "default": "Minimum number of cluster nodes"
-        },
-        "ClusterNodeInstanceType": {
-          "default": "Bitbucket cluster node instance type"
-        },
-        "DBInstanceClass": {
-          "default": "RDS instance class"
-        },
-        "DBMasterUserPassword": {
-          "default": "Master password *"
-        },
-        "DBPassword": {
-          "default": "Bitbucket database password *"
-        },
-        "DBMaster": {
-          "default": "Bitbucket primary database"
-        },
-        "DBStorage": {
-          "default": "Database storage"
-        },
-        "DBMultiAZ": {
-          "default": "Enable RDS Multi-AZ deployment"
-        },
-        "DBStorageType": {
-          "default": "Database storage type"
-        },
-        "DBIops": {
-          "default": "RDS Provisioned IOPS"
-        },
-        "DBSnapshotId": {
-          "default": "Database snapshot ID to restore"
-        },
-        "ElasticsearchInstanceType": {
-          "default": "Elasticsearch instance type"
-        },
-        "FileServerInstanceType": {
-          "default": "File server instance type"
-        },
-        "HomeDeleteOnTermination": {
-          "default": "Delete Home on termination"
-        },
-        "HomeIops": {
-          "default": "Home directory IOPS"
-        },
-        "HomeVolumeType": {
-          "default": "Home directory volume type"
-        },
-        "HomeSize": {
-          "default": "Home directory size"
-        },
-        "HomeVolumeSnapshotId": {
-          "default": "Home volume snapshot ID to restore"
-        },
-        "KeyName": {
-          "default": "Key Name *"
-        },
-        "SSLCertificateName": {
-          "default": "SSL Certificate Name"
-        },
-        "StartCollectd": {
-          "default": "Start the collectd service"
-        },
-        "ExternalSubnets": {
-          "default": "External subnets *"
-        },
-        "InternalSubnets": {
-          "default": "Internal subnets *"
-        },
-        "VPC": {
-          "default": "VPC *"
-        }
-      }
-    }
-  },
-  "Parameters": {
-    "AssociatePublicIpAddress": {
-      "Description": "Controls if the EC2 instances are assigned a public IP address",
-      "Type": "String",
-      "Default": "true",
-      "AllowedValues": [
-        "true",
-        "false"
-      ],
-      "ConstraintDescription": "Must be 'true' or 'false'."
-    },
-    "BitbucketProperties": {
-      "Description": "A comma-separated list of bitbucket properties in the form key1=value1, key2=value2, ... Find documentation at https://confluence.atlassian.com/x/m5ZKLg",
-      "Type": "CommaDelimitedList",
-      "Default": ""
-    },
-    "BitbucketVersion": {
-      "Description": "Version of Bitbucket to install, for example: 4.10.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases",
-      "Type": "String",
-      "AllowedPattern": "(\\d+\\.\\d+\\.\\d+(-?.*))",
-      "ConstraintDescription": "Must be a valid Bitbucket version number. For example: 4.10.0 or higher"
-    },
-    "CidrBlock": {
-      "Description": "The CIDR IP range that is permitted to access the Bitbucket URL. Use 0.0.0.0/0 if you want public access from the internet.",
-      "Type": "String",
-      "MinLength": "9",
-      "MaxLength": "18",
-      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
-      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
-    },
-    "ClusterNodeMin": {
-      "Type": "Number",
-      "Default": "1",
-      "Description": "Set to 1 for new instances. Can be updated post launch."
-    },
-    "ClusterNodeMax": {
-      "Type": "Number",
-      "Default": "2"
-    },
-    "ClusterNodeInstanceType": {
-      "Type": "String",
-      "Default": "c3.xlarge",
-      "AllowedValues": [
-        "c3.xlarge",
-        "c3.2xlarge",
-        "c3.4xlarge",
-        "c3.8xlarge",
-        "i2.xlarge",
-        "i2.2xlarge",
-        "i2.4xlarge",
-        "i2.8xlarge",
-        "r3.xlarge",
-        "r3.2xlarge",
-        "r3.4xlarge",
-        "r3.8xlarge",
-        "x1.32xlarge"
-      ],
-      "ConstraintDescription": "Must be an EC2 instance type in the C3, I2, R3, or X1 family, 'xlarge' or larger",
-      "Description": "Instance type for the cluster nodes. See https://confluence.atlassian.com/x/GpdKLg for guidance"
-    },
-    "CatalinaOpts": {
-      "Description": "Java options passed to the JVM that runs Bitbucket.",
-      "Type": "String",
-      "Default": ""
-    },
-    "DBInstanceClass": {
-      "Type": "String",
-      "Default": "db.m4.large",
-      "AllowedValues": [
-        "db.m4.large",
-        "db.m4.xlarge",
-        "db.m4.2xlarge",
-        "db.m4.4xlarge",
-        "db.m4.10xlarge",
-        "db.r3.large",
-        "db.r3.xlarge",
-        "db.r3.2xlarge",
-        "db.r3.4xlarge",
-        "db.r3.8xlarge",
-        "db.t2.medium",
-        "db.t2.large"
-      ],
-      "ConstraintDescription": "Must be a valid RDS instance class, 'db.t2.medium' or larger."
-    },
-    "DBMasterUserPassword": {
-      "NoEcho": "true",
-      "Description": "Password for the master ('postgres') account. Must be 8 - 128 characters.",
-      "Type": "String",
-      "MinLength": "8",
-      "MaxLength": "128",
-      "AllowedPattern": "[a-zA-Z0-9]*",
-      "ConstraintDescription": "Must be at least 8 alphanumeric characters."
-    },
-    "DBPassword": {
-      "Description": "Password for the Bitbucket user ('atlbitbucket') account. Max length of 128 characters. Not used if you have specified a Database snapshot ID.",
-      "Type": "String",
-      "MaxLength": "128",
-      "AllowedPattern": "[a-zA-Z0-9]*",
-      "ConstraintDescription": "If specified, must contain 8 to 128 alphanumeric characters",
-      "NoEcho": "true"
-    },
-    "DBMaster": {
-      "Description": "Database ARN of the RDS instance to replicate. Setting this parameter will bring up Bitbucket as a Disaster recovery standby, with an RDS read replica database.",
-      "Default": "",
-      "Type": "String",
-      "ConstraintDescription": "Must be a valid RDS ARN."
-    },
-    "DBSnapshotId": {
-      "Description": "RDS snapshot ID of an existing backup to restore. Must be used in conjunction with HomeVolumeSnapshotId. Leave blank for a new instance",
-      "Type": "String",
-      "Default": "",
-      "ConstraintDescription": "Must be a valid RDS snapshot ID, or blank."
-    },
-    "DBStorage": {
-      "Description": "Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144",
-      "Type": "Number",
-      "Default": "10",
-      "MaxValue": "6144"
-    },
-    "DBMultiAZ": {
-      "Type": "String",
-      "Default": "true",
-      "AllowedValues": [
-        "true",
-        "false"
-      ],
-      "ConstraintDescription": "Must be 'true' or 'false'."
-    },
-    "DBStorageType": {
-      "Type": "String",
-      "Default": "General Purpose (SSD)",
-      "AllowedValues": [
-        "General Purpose (SSD)",
-        "Provisioned IOPS"
-      ],
-      "ConstraintDescription": "Must be 'General Purpose (SSD)' or 'Provisioned IOPS'."
-    },
-    "DBIops": {
-      "Description": "Must be in the range of 1000 - 30000 and a multiple of 1000. This value is only used with Provisioned IOPS. Note: The ratio of IOPS per allocated-storage must be between 3.00 and 10.00.",
-      "Type": "Number",
-      "Default": "1000",
-      "MinValue": "1000",
-      "MaxValue": "30000",
-      "ConstraintDescription": "Must be in the range 1000 - 30000."
-    },
-    "ElasticsearchInstanceType": {
-      "Type": "String",
-      "Default": "m3.xlarge.elasticsearch",
-      "AllowedValues": [
-        "m3.large.elasticsearch",
-        "m3.xlarge.elasticsearch",
-        "m3.2xlarge.elasticsearch",
-        "r3.large.elasticsearch",
-        "r3.xlarge.elasticsearch",
-        "r3.2xlarge.elasticsearch",
-        "r3.4xlarge.elasticsearch",
-        "r3.8xlarge.elasticsearch",
-        "i2.xlarge.elasticsearch",
-        "i2.2xlarge.elasticsearch"
-      ],
-      "ConstraintDescription": "Must be an Elasticsearch instance type in the M3, R3 or I2 family"
-    },
-    "FileServerInstanceType": {
-      "Description": "Instance type for the file server hosting the Bitbucket shared home directory. See https://confluence.atlassian.com/x/GpdKLg for guidance",
-      "Type": "String",
-      "Default": "m4.xlarge",
-      "AllowedValues": [
-        "c4.xlarge",
-        "c4.2xlarge",
-        "c4.4xlarge",
-        "c4.8xlarge",
-        "m4.xlarge",
-        "m4.2xlarge",
-        "m4.4xlarge",
-        "m4.10xlarge",
-        "m4.16xlarge",
-        "x1.32xlarge"
-      ],
-      "ConstraintDescription": "Must be an EC2 instance type in the C4, M4, or X1 family, 'xlarge' or larger."
-    },
-    "HomeDeleteOnTermination": {
-      "Description": "Delete Bitbucket home directory volume when the file server instance is terminated.  You must back up your data before terminating your file server instance if this option is set to 'true'",
-      "Type": "String",
-      "Default": "true",
-      "AllowedValues": [
-        "true",
-        "false"
-      ],
-      "ConstraintDescription": "Must be 'true' or 'false'."
-    },
-    "HomeIops": {
-      "Description": "Home directory IOPS (100 - 20000, only used with Provisioned IOPS).  Note: The ratio of IOPS provisioned to the volume size requested can be a maximum of 50; for example, a volume with 5000 IOPS must be at least 100 GiB",
-      "Type": "Number",
-      "Default": "1000",
-      "MinValue": "100",
-      "MaxValue": "20000",
-      "ConstraintDescription": "Must be in the range 100 - 20000."
-    },
-    "HomeSize": {
-      "Description": "Home directory storage size, in gibibytes (GiB) (100 - 16384)",
-      "Type": "Number",
-      "Default": "100",
-      "MinValue": "100",
-      "MaxValue": "16384",
-      "ConstraintDescription": "Must be in the range 100 - 16384."
-    },
-    "HomeVolumeSnapshotId": {
-      "Description": "EBS snapshot ID of an existing backup to restore as the home directory volume. Must be used in conjunction with DBSnapshotId. Leave blank for a new instance",
-      "Type": "String",
-      "Default": "",
-      "ConstraintDescription": "Must be a valid EBS snapshot ID"
-    },
-    "HomeVolumeType": {
-      "Type": "String",
-      "Default": "Provisioned IOPS",
-      "AllowedValues": [
-        "General Purpose (SSD)",
-        "Provisioned IOPS"
-      ],
-      "ConstraintDescription": "Must be 'General Purpose (SSD)' or 'Provisioned IOPS'."
-    },
-    "KeyName": {
-      "Description": "The EC2 Key Pair to allow SSH access to the instances",
-      "Type": "AWS::EC2::KeyPair::KeyName",
-      "ConstraintDescription": "Must be the name of an existing EC2 Key Pair."
-    },
-    "SSLCertificateName": {
-      "Description": "The name of your Server Certificate to use for HTTPS. Refer to Amazon documentation for managing your server certificates. Leave blank if you don't want to set up HTTPS at this time",
-      "Type": "String",
-      "MinLength": "0",
-      "MaxLength": "32",
-      "Default": ""
-    },
-    "StartCollectd": {
-      "Type": "String",
-      "Default": "false",
-      "AllowedValues": [
-        "true",
-        "false"
-      ],
-      "ConstraintDescription": "Must be 'true' or 'false'"
-    },
-    "ExternalSubnets": {
-      "Description": "Subnets (two or more) where your user-facing load balancer will be deployed. MUST be within the selected VPC.",
-      "Type": "List<AWS::EC2::Subnet::Id>",
-      "ConstraintDescription": "Must be a list of two or more Subnet ID's within the selected VPC."
-    },
-    "InternalSubnets": {
-      "Description": "Subnets (two or more) where your cluster nodes and other internal infrastructure will be deployed. MUST be within the selected VPC. Specify the ExternalSubnets again here if you wish to deploy the whole stack into the same subnets.",
-      "Type": "List<AWS::EC2::Subnet::Id>",
-      "ConstraintDescription": "Must be a list of two or more Subnet ID's within the selected VPC."
-    },
-    "VPC": {
-      "Description": "Virtual Private Cloud",
-      "Type": "AWS::EC2::VPC::Id",
-      "ConstraintDescription": "Must be the ID of a VPC."
-    }
-  },
-  "Conditions": {
-    "DBProvisionedIops": {
-      "Fn::Equals": [
-        {
-          "Ref": "DBStorageType"
-        },
-        "Provisioned IOPS"
-      ]
-    },
-    "DoCollectd": {
-      "Fn::Equals": [
-        {
-          "Ref": "StartCollectd"
-        },
-        "true"
-      ]
-    },
-    "DoRestoreFromEBSSnapshot": {
-      "Fn::Not": [
-        {
-          "Fn::Equals": [
-            {
-              "Ref": "HomeVolumeSnapshotId"
-            },
-            ""
-          ]
-        }
-      ]
-    },
-    "DoRestoreFromRDSSnapshot": {
-      "Fn::Not": [
-        {
-          "Fn::Equals": [
-            {
-              "Ref": "DBSnapshotId"
-            },
-            ""
-          ]
-        }
-      ]
-    },
-    "RestoreRDSOrStandby": {
-      "Fn::Or": [
-        {
-          "Condition": "DoRestoreFromRDSSnapshot"
-        },
-        {
-          "Condition": "StandbyMode"
-        }
-      ]
-    },
-    "DoSetDBMasterUserPassword": {
-      "Fn::And": [
-        {
-          "Fn::Not": [
-            {
-              "Fn::Equals": [
-                {
-                  "Ref": "DBMasterUserPassword"
-                },
-                ""
-              ]
-            }
-          ]
-        },
-        {
-          "Condition": "NotStandbyMode"
-        }
-      ]
-    },
-    "DoSSL": {
-      "Fn::Not": [
-        {
-          "Fn::Equals": [
-            {
-              "Ref": "SSLCertificateName"
-            },
-            ""
-          ]
-        }
-      ]
-    },
-    "StandbyMode": {
-      "Fn::Not": [
-        {
-          "Fn::Equals": [
-            {
-              "Ref": "DBMaster"
-            },
-            ""
-          ]
-        }
-      ]
-    },
-    "NotStandbyMode": {
-      "Fn::Equals": [
-        {
-          "Ref": "DBMaster"
-        },
-        ""
-      ]
-    },
-    "IsHomeProvisionedIops": {
-      "Fn::Equals": [
-        {
-          "Ref": "HomeVolumeType"
-        },
-        "Provisioned IOPS"
-      ]
-    }
-  },
-  "Mappings": {
-    "AWSInstanceType2Arch": {
-      "c3.large": {
-        "Arch": "HVM64"
-      },
-      "c3.xlarge": {
-        "Arch": "HVM64"
-      },
-      "c3.2xlarge": {
-        "Arch": "HVM64"
-      },
-      "c3.4xlarge": {
-        "Arch": "HVM64"
-      },
-      "c3.8xlarge": {
-        "Arch": "HVM64"
-      },
-      "c4.large": {
-        "Arch": "HVM64"
-      },
-      "c4.xlarge": {
-        "Arch": "HVM64"
-      },
-      "c4.2xlarge": {
-        "Arch": "HVM64"
-      },
-      "c4.4xlarge": {
-        "Arch": "HVM64"
-      },
-      "c4.8xlarge": {
-        "Arch": "HVM64"
-      },
-      "d2.xlarge": {
-        "Arch": "HVM64"
-      },
-      "d2.2xlarge": {
-        "Arch": "HVM64"
-      },
-      "d2.4xlarge": {
-        "Arch": "HVM64"
-      },
-      "d2.8xlarge": {
-        "Arch": "HVM64"
-      },
-      "i2.xlarge": {
-        "Arch": "HVM64"
-      },
-      "i2.2xlarge": {
-        "Arch": "HVM64"
-      },
-      "i2.4xlarge": {
-        "Arch": "HVM64"
-      },
-      "i2.8xlarge": {
-        "Arch": "HVM64"
-      },
-      "m4.large": {
-        "Arch": "HVM64"
-      },
-      "m4.xlarge": {
-        "Arch": "HVM64"
-      },
-      "m4.2xlarge": {
-        "Arch": "HVM64"
-      },
-      "m4.4xlarge": {
-        "Arch": "HVM64"
-      },
-      "m4.10xlarge": {
-        "Arch": "HVM64"
-      },
-      "m4.16xlarge": {
-        "Arch": "HVM64"        
-      },
-      "r3.large": {
-        "Arch": "HVM64"
-      },
-      "r3.xlarge": {
-        "Arch": "HVM64"
-      },
-      "r3.2xlarge": {
-        "Arch": "HVM64"
-      },
-      "r3.4xlarge": {
-        "Arch": "HVM64"
-      },
-      "r3.8xlarge": {
-        "Arch": "HVM64"
-      },
-      "x1.32xlarge": {
-        "Arch": "HVM64"
-      }
-    },
-    "AWSRegionArch2AMI": {
-      "us-east-1": {
-        "HVM64": "ami-27bdfb30",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "ap-south-1": {
-        "HVM64": "ami-e03c488f",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "eu-west-1": {
-        "HVM64": "ami-30d09743",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "ap-southeast-1": {
-        "HVM64": "ami-efa90d8c",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "ap-southeast-2": {
-        "HVM64": "ami-6a5d6e09",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "eu-central-1": {
-        "HVM64": "ami-300bf75f",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "ap-northeast-2": {
-        "HVM64": "ami-f86fba96",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "ap-northeast-1": {
-        "HVM64": "ami-0b924d6a",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "sa-east-1": {
-        "HVM64": "ami-19f96b75",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "us-west-1": {
-        "HVM64": "ami-a0de90c0",
-        "HVMG2": "NOT_SUPPORTED"
-      },
-      "us-west-2": {
-        "HVM64": "ami-82d10fe2",
-        "HVMG2": "NOT_SUPPORTED"
-      }
-    }
-  },
-  "Resources": {
-    "BitbucketFileServerRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "ec2.amazonaws.com"
-                ]
-              },
-              "Action": [
-                "sts:AssumeRole"
-              ]
-            }
-          ]
-        },
-        "Path": "/",
-        "Policies": [
-          {
-            "PolicyName": "BitbucketFileServerPolicy",
-            "PolicyDocument": {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Action": [
-                    "ec2:AttachVolume",
-                    "ec2:CreateSnapshot",
-                    "ec2:CreateTags",
-                    "ec2:CreateVolume",
-                    "ec2:DeleteSnapshot",
-                    "ec2:DescribeInstances",
-                    "ec2:DescribeSnapshots",
-                    "ec2:DescribeVolumes",
-                    "ec2:DetachVolume",
-                    "rds:CreateDBSnapshot",
-                    "rds:DeleteDbSnapshot",
-                    "rds:DescribeDBInstances",
-                    "rds:DescribeDBSnapshots",
-                    "rds:PromoteReadReplica",
-                    "rds:ModifyDBInstance",
-                    "rds:RestoreDBInstanceFromDBSnapshot"
-                  ],
-                  "Effect": "Allow",
-                  "Resource": [
-                    "*"
-                  ]
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "BitbucketClusterNodeRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "ec2.amazonaws.com"
-                ]
-              },
-              "Action": [
-                "sts:AssumeRole"
-              ]
-            }
-          ]
-        },
-        "Path": "/",
-        "Policies": [
-          {
-            "PolicyName": "BitbucketClusterNodePolicy",
-            "PolicyDocument": {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Action": [
-                    "ec2:DescribeInstances"
-                  ],
-                  "Effect": "Allow",
-                  "Resource": [
-                    "*"
-                  ]
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "BitbucketFileServerInstanceProfile": {
-      "Type": "AWS::IAM::InstanceProfile",
-      "Properties": {
-        "Path": "/",
-        "Roles": [
-          {
-            "Ref": "BitbucketFileServerRole"
-          }
-        ]
-      }
-    },
-    "BitbucketClusterNodeInstanceProfile": {
-      "Type": "AWS::IAM::InstanceProfile",
-      "Properties": {
-        "Path": "/",
-        "Roles": [
-          {
-            "Ref": "BitbucketClusterNodeRole"
-          }
-        ]
-      }
-    },
-    "ClusterNodeGroup": {
-      "Type": "AWS::AutoScaling::AutoScalingGroup",
-      "Properties": {
-        "DesiredCapacity": {
-          "Fn::If": [
-            "StandbyMode",
-            "0",
-            {
-              "Ref": "ClusterNodeMin"
-            }
-          ]
-        },
-        "LaunchConfigurationName": {
-          "Ref": "ClusterNodeLaunchConfig"
-        },
-        "MaxSize": {
-          "Ref": "ClusterNodeMax"
-        },
-        "MinSize": {
-          "Fn::If": [
-            "StandbyMode",
-            "0",
-            {
-              "Ref": "ClusterNodeMin"
-            }
-          ]
-        },
-        "LoadBalancerNames": [
-          {
-            "Ref": "LoadBalancer"
-          }
-        ],
-        "VPCZoneIdentifier": {
-          "Ref": "InternalSubnets"
-        },
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "Bitbucket Node",
-            "PropagateAtLaunch": true
-          },
-          {
-            "Key": "Cluster",
-            "Value": {
-              "Ref": "AWS::StackName"
-            },
-            "PropagateAtLaunch": true
-          }
-        ]
-      }
-    },
-    "ClusterNodeLaunchConfig": {
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
-      "Metadata": {
-        "Comment": "",
-        "AWS::CloudFormation::Init": {
-          "1": {
-            "packages": {
-              "Fn::If": [
-                "DoCollectd",
-                {
-                  "yum": {
-                    "collectd": [],
-                    "collectd-java": [],
-                    "collectd-generic-jmx": []
-                  }
-                },
-                {
-                  "Ref": "AWS::NoValue"
-                }
-              ]
-            },
-            "files": {
-              "/etc/atl": {
-                "content": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "ATL_APP_DATA_MOUNT_ENABLED=false\n",
-                      "ATL_DB_PASSWORD=",
-                      {
-                        "Ref": "DBMasterUserPassword"
-                      },
-                      "\n",
-                      "ATL_DB_NAME=bitbucket\n",
-                      "ATL_DB_HOST=",
-                      {
-                        "Fn::GetAtt": [
-                          "DB",
-                          "Endpoint.Address"
-                        ]
-                      },
-                      "\n",
-                      "ATL_DB_PORT=",
-                      {
-                        "Fn::GetAtt": [
-                          "DB",
-                          "Endpoint.Port"
-                        ]
-                      },
-                      "\n",
-                      "ATL_JDBC_DRIVER=org.postgresql.Driver\n",
-                      "ATL_JDBC_URL=jdbc:postgresql://",
-                      {
-                        "Fn::GetAtt": [
-                          "DB",
-                          "Endpoint.Address"
-                        ]
-                      },
-                      ":",
-                      {
-                        "Fn::GetAtt": [
-                          "DB",
-                          "Endpoint.Port"
-                        ]
-                      },
-                      "/bitbucket\n",
-                      "ATL_JDBC_USER=atlbitbucket\n",
-                      "ATL_JDBC_PASSWORD=",
-                      {
-                        "Ref": "DBPassword"
-                      },
-                      "\n",
-                      "ATL_BITBUCKET_PROPERTIES=\"",
-                      {
-                        "Fn::Join": [
-                          "\n",
-                          [
-                            {
-                              "Fn::Join": [
-                                "",
-                                [
-                                  "plugin.search.elasticsearch.aws.region=",
-                                  {
-                                    "Ref": "AWS::Region"
-                                  },
-                                  "\n",
-                                  "hazelcast.network.multicast=false\n",
-                                  "hazelcast.network.aws=true\n",
-                                  "hazelcast.network.aws.iam.role=",
-                                  {
-                                    "Ref": "BitbucketClusterNodeRole"
-                                  },
-                                  "\n",
-                                  "hazelcast.network.aws.region=",
-                                  {
-                                    "Ref": "AWS::Region"
-                                  },
-                                  "\n",
-                                  "hazelcast.network.aws.tag.key=Cluster\n",
-                                  "hazelcast.network.aws.tag.value=",
-                                  {
-                                    "Ref": "AWS::StackName"
-                                  },
-                                  "\n",
-                                  "hazelcast.group.name=",
-                                  {
-                                    "Ref": "AWS::StackName"
-                                  },
-                                  "\n",
-                                  "hazelcast.group.password=",
-                                  {
-                                    "Ref": "AWS::StackName"
-                                  },
-                                  "\n",
-                                  "plugin.search.elasticsearch.baseurl=http://",
-                                  {
-                                    "Fn::GetAtt": [
-                                      "Elasticsearch",
-                                      "DomainEndpoint"
-                                    ]
-                                  },
-                                  "\n"
-                                ]
-                              ]
-                            },
-                            {
-                              "Fn::Join": [
-                                "\n",
-                                {
-                                  "Ref": "BitbucketProperties"
-                                }
-                              ]
-                            }
-                          ]
-                        ]
-                      },
-                      "\"\n",
-                      "ATL_BITBUCKET_VERSION=",
-                      {
-                        "Ref": "BitbucketVersion"
-                      },
-                      "\n",
-                      "ATL_BITBUCKET_BUNDLED_ELASTICSEARCH_ENABLED=false\n",
-                      "\n",
-                      "ATL_NGINX_ENABLED=false\n",
-                      "ATL_POSTGRES_ENABLED=false\n",
-                      "ATL_PROXY_NAME=",
-                      {
-                        "Fn::GetAtt": [
-                          "LoadBalancer",
-                          "DNSName"
-                        ]
-                      },
-                      "\n",
-                      "ATL_SSL_SELF_CERT_ENABLED=false\n",
-                      {
-                        "Fn::If": [
-                          "DoSSL",
-                          "ATL_SSL_PROXY=true\n",
-                          {
-                            "Ref": "AWS::NoValue"
-                          }
-                        ]
-                      }
-                    ]
-                  ]
-                }
-              },
-              "/etc/cfn/cfn-hup.conf": {
-                "content": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "[main]\n",
-                      "stack=",
-                      {
-                        "Ref": "AWS::StackId"
-                      },
-                      "\n",
-                      "region=",
-                      {
-                        "Ref": "AWS::Region"
-                      },
-                      "\n"
-                    ]
-                  ]
-                },
-                "mode": "000400",
-                "owner": "root",
-                "group": "root"
-              },
-              "/etc/cfn/hooks.d/cfn-auto-reloader.conf": {
-                "content": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "[cfn-auto-reloader-hook]\n",
-                      "triggers=post.update\n",
-                      "path=Resources.ClusterNodeLaunchConfig.Metadata.AWS::CloudFormation::Init\n",
-                      "action=/opt/aws/bin/cfn-init -v ",
-                      "         --stack ",
-                      {
-                        "Ref": "AWS::StackName"
-                      },
-                      "         --resource ClusterNodeLaunchConfig ",
-                      "         --region ",
-                      {
-                        "Ref": "AWS::Region"
-                      },
-                      "\n",
-                      "runas=root\n"
-                    ]
-                  ]
-                }
-              },
-              "/home/atlbitbucket/.bash_profile": {
-                "content": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "if [ -f ~/.bashrc ]; then\n",
-                      "    . ~/.bashrc\n",
-                      "fi\n",
-                      "export CATALINA_OPTS=\"",
-                      {
-                        "Ref": "CatalinaOpts"
-                      },
-                      "\"\n"
-                    ]
-                  ]
-                },
-                "mode": "000644",
-                "owner": "atlbitbucket",
-                "group": "atlbitbucket"
-              }
-            },
-            "commands": {
-              "010_add_nfs_mount": {
-                "command": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "echo ",
-                      {
-                        "Fn::GetAtt": [
-                          "FileServer",
-                          "PrivateIp"
-                        ]
-                      },
-                      ":/media/atl/bitbucket/shared /media/atl/bitbucket/shared nfs lookupcache=pos,noatime,intr,rsize=32768,wsize=32768 0 0 >>/etc/fstab"
-                    ]
-                  ]
-                },
-                "ignoreErrors": "false"
-              },
-              "020_make_shared_home_dir": {
-                "command": "mkdir -p /media/atl/bitbucket/shared",
-                "ignoreErrors": "false"
-              },
-              "030_chown_shared_home_dir": {
-                "command": "chown atlbitbucket:atlbitbucket /media/atl/bitbucket /media/atl/bitbucket/shared",
-                "ignoreErrors": "false"
-              }
-            },
-            "services": {
-              "sysvinit": {
-                "cfn-hup": {
-                  "enabled": "true",
-                  "ensureRunning": "true",
-                  "files": [
-                    "/etc/cfn/cfn-hup.conf",
-                    "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
-                  ]
-                },
-                "collectd": {
-                  "Fn::If": [
-                    "DoCollectd",
-                    {
-                      "enabled": "true",
-                      "ensureRunning": "true"
-                    },
-                    {
-                      "Ref": "AWS::NoValue"
-                    }
-                  ]
-                },
-                "rpcbind": {
-                  "enabled": "true",
-                  "ensureRunning": "true",
-                  "packages": {
-                    "yum": [
-                      "nfs-utils"
-                    ]
-                  }
-                }
-              }
-            }
-          },
-          "2": {
-            "commands": {
-              "040_mount_nfs": {
-                "command": "mount /media/atl/bitbucket/shared",
-                "ignoreErrors": "false"
-              }
-            },
-            "services": {
-              "sysvinit": {
-                "nfslock": {
-                  "enabled": "true",
-                  "ensureRunning": "true",
-                  "packages": {
-                    "yum": [
-                      "nfs-utils"
-                    ]
-                  }
-                }
-              }
-            }
-          },
-          "configSets": {
-            "default": [
-              "1",
-              "2"
-            ]
-          }
-        }
-      },
-      "Properties": {
-        "AssociatePublicIpAddress": {
-          "Ref": "AssociatePublicIpAddress"
-        },
-        "BlockDeviceMappings": [
-          {
-            "DeviceName": "/dev/xvdf",
-            "Ebs": {},
-            "NoDevice": true
-          }
-        ],
-        "KeyName": {
-          "Ref": "KeyName"
-        },
-        "IamInstanceProfile": {
-          "Ref": "BitbucketClusterNodeInstanceProfile"
-        },
-        "ImageId": {
-          "Fn::FindInMap": [
-            "AWSRegionArch2AMI",
-            {
-              "Ref": "AWS::Region"
-            },
-            {
-              "Fn::FindInMap": [
-                "AWSInstanceType2Arch",
-                {
-                  "Ref": "ClusterNodeInstanceType"
-                },
-                "Arch"
-              ]
-            }
-          ]
-        },
-        "InstanceType": {
-          "Ref": "ClusterNodeInstanceType"
-        },
-        "SecurityGroups": [
-          {
-            "Ref": "SecurityGroup"
-          }
-        ],
-        "UserData": {
-          "Fn::Base64": {
-            "Fn::Join": [
-              "",
-              [
-                "#!/bin/bash -xe\n",
-                "yum update -y aws-cfn-bootstrap\n",
-                "/opt/aws/bin/cfn-init -v ",
-                "         --stack ",
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "         --resource ClusterNodeLaunchConfig ",
-                "         --region ",
-                {
-                  "Ref": "AWS::Region"
-                },
-                "\n",
-                "/opt/aws/bin/cfn-signal -e $? ",
-                "         --stack ",
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "         --resource ClusterNodeGroup ",
-                "         --region ",
-                {
-                  "Ref": "AWS::Region"
-                },
-                "\n"
-              ]
-            ]
-          }
-        }
-      }
-    },
-    "ClusterNodeScaleUpPolicy": {
-      "Type": "AWS::AutoScaling::ScalingPolicy",
-      "Properties": {
-        "AdjustmentType": "ChangeInCapacity",
-        "AutoScalingGroupName": {
-          "Ref": "ClusterNodeGroup"
-        },
-        "Cooldown": "600",
-        "ScalingAdjustment": "1"
-      }
-    },
-    "ClusterNodeScaleDownPolicy": {
-      "Type": "AWS::AutoScaling::ScalingPolicy",
-      "Properties": {
-        "AdjustmentType": "ChangeInCapacity",
-        "AutoScalingGroupName": {
-          "Ref": "ClusterNodeGroup"
-        },
-        "Cooldown": "600",
-        "ScalingAdjustment": "-1"
-      }
-    },
-    "CPUAlarmHigh": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "Properties": {
-        "AlarmDescription": "Scale up if CPU > 60% for 5 minutes",
-        "MetricName": "CPUUtilization",
-        "Namespace": "AWS/EC2",
-        "Statistic": "Average",
-        "Period": "60",
-        "EvaluationPeriods": "5",
-        "Threshold": "60",
-        "AlarmActions": [
-          {
-            "Ref": "ClusterNodeScaleUpPolicy"
-          }
-        ],
-        "Dimensions": [
-          {
-            "Name": "AutoScalingGroupName",
-            "Value": {
-              "Ref": "ClusterNodeGroup"
-            }
-          }
-        ],
-        "ComparisonOperator": "GreaterThanThreshold"
-      }
-    },
-    "CPUAlarmLow": {
-      "Type": "AWS::CloudWatch::Alarm",
-      "Properties": {
-        "AlarmDescription": "Scale down if CPU < 40% for 30 minutes",
-        "MetricName": "CPUUtilization",
-        "Namespace": "AWS/EC2",
-        "Statistic": "Average",
-        "Period": "60",
-        "EvaluationPeriods": "30",
-        "Threshold": "40",
-        "AlarmActions": [
-          {
-            "Ref": "ClusterNodeScaleDownPolicy"
-          }
-        ],
-        "Dimensions": [
-          {
-            "Name": "AutoScalingGroupName",
-            "Value": {
-              "Ref": "ClusterNodeGroup"
-            }
-          }
-        ],
-        "ComparisonOperator": "LessThanThreshold"
-      }
-    },
-    "Elasticsearch": {
-      "Type": "AWS::Elasticsearch::Domain",
-      "Properties": {
-        "AccessPolicies": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": {
-                  "Fn::GetAtt": [
-                    "BitbucketClusterNodeRole",
-                    "Arn"
-                  ]
-                }
-              },
-              "Action": "es:*",
-              "Resource": "*"
-            },
-            {
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": {
-                  "Fn::GetAtt": [
-                    "BitbucketFileServerRole",
-                    "Arn"
-                  ]
-                }
-              },
-              "Action": "es:*",
-              "Resource": "*"
-            }
-          ]
-        },
-        "ElasticsearchVersion": "2.3",
-        "ElasticsearchClusterConfig": {
-          "InstanceType": {
-            "Ref": "ElasticsearchInstanceType"
-          }
-        },
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "Bitbucket Elasticsearch cluster"
-          },
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackId"
-            }
-          }
-        ]
-      }
-    },
-    "FileServer": {
-      "Type": "AWS::EC2::Instance",
-      "Metadata": {
-        "Comment": "Set up NFS Server and initial bitbucket.properties",
-        "AWS::CloudFormation::Init": {
-          "1": {
-            "packages": {
-              "Fn::If": [
-                "DoCollectd",
-                {
-                  "yum": {
-                    "collectd": [],
-                    "collectd-java": [],
-                    "collectd-generic-jmx": []
-                  }
-                },
-                {
-                  "Ref": "AWS::NoValue"
-                }
-              ]
-            },
-            "files": {
-              "/etc/atl": {
-                "content": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "ATL_ENABLED_PRODUCTS=\n",
-                      "ATL_ENABLED_SHARED_HOMES=Bitbucket\n",
-                      "ATL_NGINX_ENABLED=false\n",
-                      "ATL_POSTGRES_ENABLED=false\n",
-                      "ATL_SSL_SELF_CERT_ENABLED=false\n",
-                      "ATL_BITBUCKET_BUNDLED_ELASTICSEARCH_ENABLED=false\n",
-                      "ATL_APP_NFS_SERVER=true\n"
-                    ]
-                  ]
-                }
-              },
-              "/etc/cfn/cfn-hup.conf": {
-                "content": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "[main]\n",
-                      "stack=",
-                      {
-                        "Ref": "AWS::StackId"
-                      },
-                      "\n",
-                      "region=",
-                      {
-                        "Ref": "AWS::Region"
-                      },
-                      "\n"
-                    ]
-                  ]
-                },
-                "mode": "000400",
-                "owner": "root",
-                "group": "root"
-              },
-              "/etc/cfn/hooks.d/cfn-auto-reloader.conf": {
-                "content": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "[cfn-auto-reloader-hook]\n",
-                      "triggers=post.update\n",
-                      "path=Resources.FileServer.Metadata.AWS::CloudFormation::Init\n",
-                      "action=/opt/aws/bin/cfn-init -v ",
-                      "         --stack ",
-                      {
-                        "Ref": "AWS::StackName"
-                      },
-                      "         --resource FileServer ",
-                      "         --region ",
-                      {
-                        "Ref": "AWS::Region"
-                      },
-                      "\n",
-                      "runas=root\n"
-                    ]
-                  ]
-                }
-              },
-              "/opt/atlassian/bitbucket-diy-backup/bitbucket.diy-backup.vars.sh": {
-                "content": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "# This file was generated from the BitbucketDataCenter CloudFormation template\n",
-                      {
-                        "Fn::Join": [
-                          "",
-                          [
-                            "INSTANCE_NAME=",
-                            {
-                              "Ref": "AWS::StackName"
-                            },
-                            "\n"
-                          ]
-                        ]
-                      },
-                      {
-                        "Fn::Join": [
-                          "",
-                          [
-                            "BITBUCKET_URL=",
-                            {
-                              "Fn::Join": [
-                                "",
-                                [
-                                  {
-                                    "Fn::If": [
-                                      "DoSSL",
-                                      "https",
-                                      "http"
-                                    ]
-                                  },
-                                  "://",
-                                  {
-                                    "Fn::GetAtt": [
-                                      "LoadBalancer",
-                                      "DNSName"
-                                    ]
-                                  }
-                                ]
-                              ]
-                            },
-                            "\n"
-                          ]
-                        ]
-                      },
-                      "BITBUCKET_HOME=/media/atl/bitbucket\n",
-                      "BITBUCKET_UID=atlbitbucket\n",
-                      "BITBUCKET_GID=atlbitbucket\n",
-                      "BACKUP_HOME_TYPE=amazon-ebs\n",
-                      "BACKUP_DATABASE_TYPE=amazon-rds\n",
-                      "BACKUP_ARCHIVE_TYPE=\n",
-                      "BACKUP_ZERO_DOWNTIME=true\n",
-                      "HOME_DIRECTORY_MOUNT_POINT=/media/atl\n",
-                      "HOME_DIRECTORY_DEVICE_NAME=/dev/sdf\n",
-                      {
-                        "Fn::Join": [
-                          "",
-                          [
-                            "RESTORE_HOME_DIRECTORY_VOLUME_TYPE=",
-                            {
-                              "Fn::If": [
-                                "IsHomeProvisionedIops",
-                                "io1",
-                                "gp2"
-                              ]
-                            },
-                            "\n"
-                          ]
-                        ]
-                      },
-                      {
-                        "Fn::If": [
-                          "IsHomeProvisionedIops",
-                          {
-                            "Fn::Join": [
-                              "",
-                              [
-                                "RESTORE_HOME_DIRECTORY_IOPS=",
-                                {
-                                  "Ref": "HomeIops"
-                                },
-                                "\n"
-                              ]
-                            ]
-                          },
-                          {
-                            "Ref": "AWS::NoValue"
-                          }
-                        ]
-                      },
-                      "FILESYSTEM_TYPE=zfs\n",
-                      "ZFS_HOME_TANK_NAME=$(run sudo zfs list -H -o name,mountpoint | grep \"${HOME_DIRECTORY_MOUNT_POINT}\" | cut -f1)\n",
-                      {
-                        "Fn::Join": [
-                          "",
-                          [
-                            "RDS_INSTANCE_ID=",
-                            {
-                              "Ref": "DB"
-                            },
-                            "\n"
-                          ]
-                        ]
-                      },
-                      {
-                        "Fn::Join": [
-                          "",
-                          [
-                            "RESTORE_RDS_INSTANCE_CLASS=",
-                            {
-                              "Ref": "DBInstanceClass"
-                            },
-                            "\n"
-                          ]
-                        ]
-                      },
-                      {
-                        "Fn::Join": [
-                          "",
-                          [
-                            "RESTORE_RDS_MULTI_AZ=",
-                            {
-                              "Ref": "DBMultiAZ"
-                            },
-                            "\n"
-                          ]
-                        ]
-                      },
-                      {
-                        "Fn::Join": [
-                          "",
-                          [
-                            "RESTORE_RDS_SUBNET_GROUP_NAME=",
-                            {
-                              "Ref": "DBSubnetGroup"
-                            },
-                            "\n"
-                          ]
-                        ]
-                      },
-                      {
-                        "Fn::Join": [
-                          "",
-                          [
-                            "RESTORE_RDS_SECURITY_GROUP=",
-                            {
-                              "Ref": "SecurityGroup"
-                            },
-                            "\n"
-                          ]
-                        ]
-                      },
-                      "CURL_OPTIONS=\"-L -s -f\"\n",
-                      {
-                        "Fn::Join": [
-                          "",
-                          [
-                            "AWS_REGION=",
-                            {
-                              "Ref": "AWS::Region"
-                            },
-                            "\n"
-                          ]
-                        ]
-                      },
-                      "AWS_INFO=$(curl ${CURL_OPTIONS} http://169.254.169.254/latest/dynamic/instance-identity/document)\n",
-                      "AWS_AVAILABILITY_ZONE=$(echo \"${AWS_INFO}\" | jq -r .availabilityZone)\n",
-                      "AWS_REGION=$(echo \"${AWS_INFO}\" | jq -r .region)\n",
-                      "AWS_EC2_INSTANCE_ID=$(echo \"${AWS_INFO}\" | jq -r .instanceId)\n",
-                      "AWS_ADDITIONAL_TAGS=\n",
-                      "BITBUCKET_VERBOSE_BACKUP=${BITBUCKET_VERBOSE_BACKUP:-true}\n",
-                      "KEEP_BACKUPS=5"
-                    ]
-                  ]
-                },
-                "mode": "000644",
-                "owner": "ec2-user",
-                "group": "ec2-user"
-              }
-            },
-            "services": {
-              "sysvinit": {
-                "cfn-hup": {
-                  "enabled": "true",
-                  "ensureRunning": "true",
-                  "files": [
-                    "/etc/cfn/cfn-hup.conf",
-                    "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
-                  ]
-                },
-                "collectd": {
-                  "Fn::If": [
-                    "DoCollectd",
-                    {
-                      "enabled": "true",
-                      "ensureRunning": "true"
-                    },
-                    {
-                      "Ref": "AWS::NoValue"
-                    }
-                  ]
-                },
-                "rpcbind": {
-                  "enabled": "true",
-                  "ensureRunning": "true"
-                }
-              }
-            }
-          },
-          "2": {
-            "services": {
-              "sysvinit": {
-                "nfs": {
-                  "enabled": "true",
-                  "ensureRunning": "true"
-                },
-                "nfslock": {
-                  "enabled": "true",
-                  "ensureRunning": "true"
-                }
-              }
-            }
-          },
-          "configSets": {
-            "default": [
-              "1",
-              "2"
-            ]
-          }
-        }
-      },
-      "Properties": {
-        "BlockDeviceMappings": [
-          {
-            "DeviceName": "/dev/sdf",
-            "Ebs": {
-              "VolumeType": {
-                "Fn::If": [
-                  "IsHomeProvisionedIops",
-                  "io1",
-                  "gp2"
-                ]
-              },
-              "Iops": {
-                "Fn::If": [
-                  "IsHomeProvisionedIops",
-                  {
-                    "Ref": "HomeIops"
-                  },
-                  {
-                    "Ref": "AWS::NoValue"
-                  }
-                ]
-              },
-              "DeleteOnTermination": {
-                "Ref": "HomeDeleteOnTermination"
-              },
-              "SnapshotId": {
-                "Fn::If": [
-                  "DoRestoreFromEBSSnapshot",
-                  {
-                    "Ref": "HomeVolumeSnapshotId"
-                  },
-                  {
-                    "Ref": "AWS::NoValue"
-                  }
-                ]
-              },
-              "VolumeSize": {
-                "Ref": "HomeSize"
-              }
-            }
-          },
-          {
-            "DeviceName": "/dev/xvdf",
-            "NoDevice": {}
-          }
-        ],
-        "IamInstanceProfile": {
-          "Ref": "BitbucketFileServerInstanceProfile"
-        },
-        "ImageId": {
-          "Fn::FindInMap": [
-            "AWSRegionArch2AMI",
-            {
-              "Ref": "AWS::Region"
-            },
-            {
-              "Fn::FindInMap": [
-                "AWSInstanceType2Arch",
-                {
-                  "Ref": "FileServerInstanceType"
-                },
-                "Arch"
-              ]
-            }
-          ]
-        },
-        "InstanceType": {
-          "Ref": "FileServerInstanceType"
-        },
-        "KeyName": {
-          "Ref": "KeyName"
-        },
-        "NetworkInterfaces": [
-          {
-            "GroupSet": [
-              {
-                "Ref": "SecurityGroup"
-              }
-            ],
-            "AssociatePublicIpAddress": {
-              "Ref": "AssociatePublicIpAddress"
-            },
-            "DeviceIndex": "0",
-            "DeleteOnTermination": "true",
-            "SubnetId": {
-              "Fn::Select": [
-                "0",
-                {
-                  "Ref": "InternalSubnets"
-                }
-              ]
-            }
-          }
-        ],
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "Bitbucket NFS Server"
-          },
-          {
-            "Key": "Application",
-            "Value": {
-              "Ref": "AWS::StackId"
-            }
-          }
-        ],
-        "UserData": {
-          "Fn::Base64": {
-            "Fn::Join": [
-              "",
-              [
-                "#!/bin/bash -xe\n",
-                "yum update -y aws-cfn-bootstrap\n",
-                "/opt/aws/bin/cfn-init -v ",
-                "         --stack ",
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "         --resource FileServer ",
-                "         --region ",
-                {
-                  "Ref": "AWS::Region"
-                },
-                "\n",
-                "/opt/aws/bin/cfn-signal -e $? ",
-                "         --stack ",
-                {
-                  "Ref": "AWS::StackName"
-                },
-                "         --resource FileServer ",
-                "         --region ",
-                {
-                  "Ref": "AWS::Region"
-                },
-                "\n"
-              ]
-            ]
-          }
-        }
-      }
-    },
-    "DB": {
-      "Type": "AWS::RDS::DBInstance",
-      "Properties": {
-        "SourceDBInstanceIdentifier": {
-          "Fn::If": [
-            "StandbyMode",
-            {
-              "Ref": "DBMaster"
-            },
-            {
-              "Ref": "AWS::NoValue"
-            }
-          ]
-        },
-        "DBName": {
-          "Fn::If": [
-            "RestoreRDSOrStandby",
-            {
-              "Ref": "AWS::NoValue"
-            },
-            "bitbucket"
-          ]
-        },
-        "AllocatedStorage": {
-          "Ref": "DBStorage"
-        },
-        "DBInstanceClass": {
-          "Ref": "DBInstanceClass"
-        },
-        "DBSnapshotIdentifier": {
-          "Fn::If": [
-            "DoRestoreFromRDSSnapshot",
-            {
-              "Ref": "DBSnapshotId"
-            },
-            {
-              "Ref": "AWS::NoValue"
-            }
-          ]
-        },
-        "DBSubnetGroupName": {
-          "Ref": "DBSubnetGroup"
-        },
-        "Engine": "postgres",
-        "EngineVersion": "9.5.2",
-        "MasterUsername": "postgres",
-        "MasterUserPassword": {
-          "Fn::If": [
-            "DoSetDBMasterUserPassword",
-            {
-              "Ref": "DBMasterUserPassword"
-            },
-            {
-              "Ref": "AWS::NoValue"
-            }
-          ]
-        },
-        "StorageType": {
-          "Fn::If": [
-            "DBProvisionedIops",
-            "io1",
-            "gp2"
-          ]
-        },
-        "Iops": {
-          "Fn::If": [
-            "DBProvisionedIops",
-            {
-              "Ref": "DBIops"
-            },
-            {
-              "Ref": "AWS::NoValue"
-            }
-          ]
-        },
-        "MultiAZ": {
-          "Fn::If": [
-            "StandbyMode",
-            {
-              "Ref": "AWS::NoValue"
-            },
-            {
-              "Ref": "DBMultiAZ"
-            }
-          ]
-        },
-        "VPCSecurityGroups": [
-          {
-            "Ref": "SecurityGroup"
-          }
-        ],
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "Bitbucket PostgreSQL Database"
-          }
-        ]
-      }
-    },
-    "DBSubnetGroup": {
-      "Type": "AWS::RDS::DBSubnetGroup",
-      "Properties": {
-        "DBSubnetGroupDescription": "DBSubnetGroup",
-        "SubnetIds": {
-          "Ref": "InternalSubnets"
-        }
-      }
-    },
-    "LoadBalancer": {
-      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
-      "Properties": {
-        "AppCookieStickinessPolicy": [
-          {
-            "CookieName": "JSESSIONID",
-            "PolicyName": "JSessionIdStickiness"
-          }
-        ],
-        "ConnectionDrainingPolicy": {
-          "Enabled": true,
-          "Timeout": 300
-        },
-        "ConnectionSettings": {
-          "IdleTimeout": 3600
-        },
-        "CrossZone": "true",
-        "Listeners": [
-          {
-            "LoadBalancerPort": "80",
-            "Protocol": "HTTP",
-            "InstancePort": {
-              "Fn::If": [
-                "DoSSL",
-                "7991",
-                "7990"
-              ]
-            },
-            "InstanceProtocol": "HTTP",
-            "PolicyNames": [
-              "JSessionIdStickiness"
-            ]
-          },
-          {
-            "Fn::If": [
-              "DoSSL",
-              {
-                "LoadBalancerPort": "443",
-                "Protocol": "HTTPS",
-                "InstancePort": "7990",
-                "InstanceProtocol": "HTTP",
-                "PolicyNames": [
-                  "JSessionIdStickiness"
-                ],
-                "SSLCertificateId": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:iam::",
-                      {
-                        "Ref": "AWS::AccountId"
-                      },
-                      ":server-certificate/",
-                      {
-                        "Ref": "SSLCertificateName"
-                      }
-                    ]
-                  ]
-                }
-              },
-              {
-                "Ref": "AWS::NoValue"
-              }
-            ]
-          },
-          {
-            "LoadBalancerPort": "7999",
-            "Protocol": "TCP",
-            "InstancePort": "7999",
-            "InstanceProtocol": "TCP"
-          }
-        ],
-        "HealthCheck": {
-          "Target": "HTTP:7990/status",
-          "Timeout": "29",
-          "Interval": "30",
-          "UnhealthyThreshold": "2",
-          "HealthyThreshold": "2"
-        },
-        "Scheme": "internet-facing",
-        "SecurityGroups": [
-          {
-            "Ref": "SecurityGroup"
-          }
-        ],
-        "Subnets": {
-          "Ref": "ExternalSubnets"
-        }
-      }
-    },
-    "SecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
-      "Properties": {
-        "GroupDescription": "Security group allowing SSH and HTTP/HTTPS access",
-        "VpcId": {
-          "Ref": "VPC"
-        },
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "22",
-            "ToPort": "22",
-            "CidrIp": {
-              "Ref": "CidrBlock"
-            }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "80",
-            "ToPort": "80",
-            "CidrIp": {
-              "Ref": "CidrBlock"
-            }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "443",
-            "ToPort": "443",
-            "CidrIp": {
-              "Ref": "CidrBlock"
-            }
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "7999",
-            "ToPort": "7999",
-            "CidrIp": {
-              "Ref": "CidrBlock"
-            }
-          }
-        ]
-      }
-    },
-    "SecurityGroupIngress": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupId": {
-          "Ref": "SecurityGroup"
-        },
-        "IpProtocol": "-1",
-        "FromPort": "-1",
-        "ToPort": "-1",
-        "SourceSecurityGroupId": {
-          "Ref": "SecurityGroup"
-        }
-      }
-    }
-  },
-  "Outputs": {
-    "ClusterNodeGroup": {
-      "Description": "The name of the auto scaling group of cluster nodes",
-      "Value": {
-        "Ref": "ClusterNodeGroup"
-      }
-    },
-    "FileServer": {
-      "Description": "The public DNS name of the FileServer node",
-      "Value": {
-        "Fn::GetAtt": [
-          "FileServer",
-          "PublicDnsName"
-        ]
-      }
-    },
-    "URL": {
-      "Description": "The URL of the Bitbucket Data Center instance",
-      "Value": {
-        "Fn::Join": [
-          "",
-          [
-            {
-              "Fn::If": [
-                "DoSSL",
-                "https",
-                "http"
-              ]
-            },
-            "://",
-            {
-              "Fn::GetAtt": [
-                "LoadBalancer",
-                "DNSName"
-              ]
-            }
-          ]
-        ]
-      }
-    },
-    "DBMaster": {
-      "Description": "The RDS ARN to use when creating a Data Center standby stack",
-      "Value": {
-        "Fn::If": [
-          "NotStandbyMode",
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:rds:",
-                {
-                  "Ref": "AWS::Region"
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId"
-                },
-                ":db:",
-                {
-                  "Ref": "DB"
-                }
-              ]
-            ]
-          },
-          {
-            "Ref": "AWS::NoValue"
-          }
-        ]
-      }
-    }
-  }
-}
+---
+AWSTemplateFormatVersion: 2010-09-09
+Description: QS(0034) Atlassian Bitbucket Data Center Oct,19,2016
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Bitbucket setup
+        Parameters: [BitbucketVersion]
+      - Label:
+          default: Cluster nodes
+        Parameters: [ClusterNodeInstanceType, ClusterNodeMin, ClusterNodeMax]
+      - Label:
+          default: File server
+        Parameters: [FileServerInstanceType, HomeSize, HomeVolumeType, HomeIops]
+      - Label:
+          default: Database
+        Parameters:
+          - DBInstanceClass
+          - DBMasterUserPassword
+          - DBPassword
+          - DBStorage
+          - DBStorageType
+          - DBIops
+          - DBMultiAZ
+      - Label:
+          default: Elasticsearch
+        Parameters: [ElasticsearchInstanceType]
+      - Label:
+          default: Networking
+        Parameters:
+          - VPC
+          - ExternalSubnets
+          - InternalSubnets
+          - AssociatePublicIpAddress
+          - CidrBlock
+          - KeyName
+          - SSLCertificateName
+      - Label:
+          default: Advanced (Optional)
+        Parameters:
+          - DBSnapshotId
+          - HomeVolumeSnapshotId
+          - ESSnapshotId
+          - BitbucketProperties
+          - CatalinaOpts
+          - AMIOpts
+          - HomeDeleteOnTermination
+          - DBMaster
+          - StartCollectd
+          - ESBucketName
+    ParameterLabels:
+      AMIOpts:
+        default: AMI Options
+      AssociatePublicIpAddress:
+        default: Assign public IP
+      BitbucketProperties:
+        default: Bitbucket properties
+      BitbucketVersion:
+        default: Version *
+      CatalinaOpts:
+        default: Catalina options
+      CidrBlock:
+        default: Permitted IP range *
+      ClusterNodeMax:
+        default: Maximum number of cluster nodes
+      ClusterNodeMin:
+        default: Minimum number of cluster nodes
+      ClusterNodeInstanceType:
+        default: Bitbucket cluster node instance type
+      DBInstanceClass:
+        default: RDS instance class
+      DBMasterUserPassword:
+        default: Master password *
+      DBPassword:
+        default: Bitbucket database password *
+      DBMaster:
+        default: Bitbucket primary database
+      DBStorage:
+        default: Database storage
+      DBMultiAZ:
+        default: Enable RDS Multi-AZ deployment
+      DBStorageType:
+        default: Database storage type
+      DBIops:
+        default: RDS Provisioned IOPS
+      DBSnapshotId:
+        default: Database snapshot ID to restore
+      ElasticsearchInstanceType:
+        default: Elasticsearch instance type
+      ESBucketName:
+        default: Elasticsearch snapshot S3 bucket name
+      ESSnapshotId:
+        default: Elasticsearch snapshot ID to restore
+      FileServerInstanceType:
+        default: File server instance type
+      HomeDeleteOnTermination:
+        default: Delete Home on termination
+      HomeIops:
+        default: Home directory IOPS
+      HomeVolumeType:
+        default: Home directory volume type
+      HomeSize:
+        default: Home directory size
+      HomeVolumeSnapshotId:
+        default: Home volume snapshot ID to restore
+      KeyName:
+        default: Key Name *
+      SSLCertificateName:
+        default: SSL Certificate Name
+      StartCollectd:
+        default: Start the collectd service
+      ExternalSubnets:
+        default: External Subnets *
+      InternalSubnets:
+        default: Internal Subnets *
+      VPC:
+        default: VPC *
+Parameters:
+  AMIOpts:
+    Description: A comma separated list of options to pass to the AMI
+    Type: CommaDelimitedList
+    Default: ""
+  AssociatePublicIpAddress:
+    Description: Controls if the EC2 instances are assigned a public IP address
+    Type: String
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+  BitbucketProperties:
+    Description: A comma-separated list of bitbucket properties in the form key1=value1, key2=value2, ... Find documentation at https://confluence.atlassian.com/x/m5ZKLg
+    Type: CommaDelimitedList
+    Default: ""
+  BitbucketVersion:
+    Description: "Version of Bitbucket to install, for example: 4.10.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases"
+    Type: String
+    AllowedPattern: "(\\d+\\.\\d+\\.\\d+(-?.*))"
+    ConstraintDescription: "Must be a valid Bitbucket version number. For example: 4.10.0 or higher"
+  CidrBlock:
+    Description: The CIDR IP range that is permitted to access the Bitbucket URL. Use 0.0.0.0/0 if you want public access from the internet.
+    Type: String
+    MinLength: 9
+    MaxLength: 18
+    AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
+    ConstraintDescription: Must be a valid IP CIDR range of the form x.x.x.x/x.
+  ClusterNodeMin:
+    Type: Number
+    Default: 1
+    Description: Set to 1 for new instances. Can be updated post launch.
+  ClusterNodeMax:
+    Type: Number
+    Default: 2
+  ClusterNodeInstanceType:
+    Type: String
+    Default: c3.xlarge
+    AllowedValues:
+      - c3.xlarge
+      - c3.2xlarge
+      - c3.4xlarge
+      - c3.8xlarge
+      - i2.xlarge
+      - i2.2xlarge
+      - i2.4xlarge
+      - i2.8xlarge
+      - r3.xlarge
+      - r3.2xlarge
+      - r3.4xlarge
+      - r3.8xlarge
+      - x1.32xlarge
+    ConstraintDescription: Must be an EC2 instance type in the C3, I2, R3, or X1 family, 'xlarge' or larger
+    Description: "Instance type for the cluster nodes. See https://confluence.atlassian.com/x/GpdKLg for guidance"
+  CatalinaOpts:
+    Description: Java options passed to the JVM that runs Bitbucket.
+    Type: String
+    Default: ""
+  DBInstanceClass:
+    Type: String
+    Default: db.m4.large
+    AllowedValues:
+      - db.m4.large
+      - db.m4.xlarge
+      - db.m4.2xlarge
+      - db.m4.4xlarge
+      - db.m4.10xlarge
+      - db.r3.large
+      - db.r3.xlarge
+      - db.r3.2xlarge
+      - db.r3.4xlarge
+      - db.r3.8xlarge
+      - db.t2.medium
+      - db.t2.large
+    ConstraintDescription: Must be a valid RDS instance class, 'db.t2.medium' or larger.
+  DBMasterUserPassword:
+    NoEcho: true
+    Description: Password for the master ('postgres') account. Must be 8 - 128 characters.
+    Type: String
+    MinLength: 8
+    MaxLength: 128
+    AllowedPattern: "[a-zA-Z0-9]*"
+    ConstraintDescription: Must be at least 8 alphanumeric characters.
+  DBPassword:
+    Description: Password for the Bitbucket user ('atlbitbucket') account. Max length of 128 characters. Not used if you have specified a Database snapshot ID.
+    Type: String
+    MaxLength: 128
+    AllowedPattern: "[a-zA-Z0-9]*"
+    ConstraintDescription: If specified, must contain 8 to 128 alphanumeric characters
+    NoEcho: true
+  DBMaster:
+    Description: Database ARN of the RDS instance to replicate. Setting this parameter will bring up Bitbucket as a Disaster recovery standby, with an RDS read replica database.
+    Default: ""
+    Type: String
+    ConstraintDescription: Must be a valid RDS ARN.
+  DBSnapshotId:
+    Description: RDS snapshot ID of an existing backup to restore. Must be used in conjunction with HomeVolumeSnapshotId. Leave blank for a new instance
+    Type: String
+    Default: ""
+    ConstraintDescription: Must be a valid RDS snapshot ID, or blank.
+  DBStorage:
+    Description: Database allocated storage size, in gigabytes (GB). If you choose Provisioned IOPS, storage should be between 100 and 6144
+    Type: Number
+    Default: 10
+    MinValue: 5
+    MaxValue: 6144
+  DBMultiAZ:
+    Type: String
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+  DBStorageType:
+    Type: String
+    Default: General Purpose (SSD)
+    AllowedValues: [General Purpose (SSD), Provisioned IOPS]
+    ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
+  DBIops:
+    Default: 1000
+    Description: "Must be in the range of 1000 - 30000 and a multiple of 1000. This value is only used with Provisioned IOPS. Note: The ratio of IOPS per allocated-storage must be between 3.00 and 10.00."
+    Type: Number
+    MinValue: 1000
+    MaxValue: 30000
+    ConstraintDescription: Must be in the range 1000 - 30000.
+  ElasticsearchInstanceType:
+    Type: String
+    Default: m3.xlarge.elasticsearch
+    AllowedValues:
+      - m3.large.elasticsearch
+      - m3.xlarge.elasticsearch
+      - m3.2xlarge.elasticsearch
+      - r3.large.elasticsearch
+      - r3.xlarge.elasticsearch
+      - r3.2xlarge.elasticsearch
+      - r3.4xlarge.elasticsearch
+      - r3.8xlarge.elasticsearch
+      - i2.xlarge.elasticsearch
+      - i2.2xlarge.elasticsearch
+    ConstraintDescription: Must be an Elasticsearch instance type in the M3, R3 or I2 family
+  ESBucketName:
+    Type: String
+    Default: ""
+    Description: "Name of a new, or existing, S3 bucket configured for Elasticsearch snapshots"
+    ConstraintDescription: "Must contain only lowercase letters, numbers and hyphens (-)."
+    AllowedPattern: "[a-z0-9-]*"
+  ESSnapshotId:
+    Type: String
+    Default: ""
+    Description: "Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket"
+    AllowedPattern: "[a-z0-9-]*"
+    ConstraintDescription: "Must contain only lowercase letters, numbers and hyphens (-)."
+  FileServerInstanceType:
+    Description: "Instance type for the file server hosting the Bitbucket shared home directory. See https://confluence.atlassian.com/x/GpdKLg for guidance"
+    Type: String
+    Default: m4.xlarge
+    AllowedValues:
+      - c4.xlarge
+      - c4.2xlarge
+      - c4.4xlarge
+      - c4.8xlarge
+      - m4.xlarge
+      - m4.2xlarge
+      - m4.4xlarge
+      - m4.10xlarge
+      - m4.16xlarge
+      - x1.32xlarge
+    ConstraintDescription: Must be an EC2 instance type in the C4, M4, or X1 family, 'xlarge' or larger.
+  HomeDeleteOnTermination:
+    Description: Delete Bitbucket home directory volume when the file server instance is terminated.  You must back up your data before terminating your file server instance if this option is set to 'true'
+    Type: String
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+  HomeIops:
+    Description: "Home directory IOPS (100 - 20000, only used with Provisioned IOPS).  Note: The ratio of IOPS provisioned to the volume size requested can be a maximum of 50; for example, a volume with 5000 IOPS must be at least 100 GiB"
+    Type: Number
+    Default: 1000
+    MinValue: 100
+    MaxValue: 20000
+    ConstraintDescription: Must be in the range 100 - 20000.
+  HomeSize:
+    Description: Home directory storage size, in gibibytes (GiB) (100 - 16384)
+    Type: Number
+    Default: 100
+    MinValue: 100
+    MaxValue: 16384
+    ConstraintDescription: Must be in the range 100 - 16384.
+  HomeVolumeSnapshotId:
+    Description: EBS snapshot ID of an existing backup to restore as the home directory volume. Must be used in conjunction with DBSnapshotId. Leave blank for a new instance
+    Type: String
+    Default: ""
+    ConstraintDescription: Must be a valid EBS snapshot ID
+  HomeVolumeType:
+    Type: String
+    Default: Provisioned IOPS
+    AllowedValues: [General Purpose (SSD), Provisioned IOPS]
+    ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
+  KeyName:
+    Description: The EC2 Key Pair to allow SSH access to the instances
+    Type: "AWS::EC2::KeyPair::KeyName"
+    ConstraintDescription: Must be the name of an existing EC2 Key Pair.
+  SSLCertificateName:
+    Description: The name of your Server Certificate to use for HTTPS. Refer to Amazon documentation for managing your server certificates. Leave blank if you don't want to set up HTTPS at this time
+    Type: String
+    MinLength: 0
+    MaxLength: 32
+    Default: ""
+  StartCollectd:
+    Type: String
+    Default: false
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'
+  ExternalSubnets:
+    Description: Subnets (two or more) where your user-facing load balancer will be deployed. MUST be within the selected VPC.
+    Type: "List<AWS::EC2::Subnet::Id>"
+    ConstraintDescription: Must be a list of two or more Subnet ID's within the selected VPC.
+  InternalSubnets:
+    Description: Subnets (two or more) where your cluster nodes and other internal infrastructure will be deployed. MUST be within the selected VPC. Specify the ExternalSubnets again here if you wish to deploy the whole stack into the same subnets.
+    Type: List<AWS::EC2::Subnet::Id>
+    ConstraintDescription: Must be a list of two or more Subnet ID's within the selected VPC.
+  VPC:
+    Description: Virtual Private Cloud
+    Type: "AWS::EC2::VPC::Id"
+    ConstraintDescription: Must be the ID of a VPC.
+Conditions:
+  DBProvisionedIops:
+    !Equals [!Ref DBStorageType, Provisioned IOPS]
+  SetupCollectd:
+    !Equals [!Ref StartCollectd, true]
+  RestoreFromEBSSnapshot:
+    !Not [!Equals [!Ref HomeVolumeSnapshotId, ""]]
+  RestoreFromRDSSnapshot:
+    !Not [!Equals [!Ref DBSnapshotId, ""]]
+  RestoreFromESSnapshot:
+    !And
+      - !Not [!Equals [!Ref ESSnapshotId, ""]]
+      - !Not [Condition: ESBucketNameSet]
+  CreateESBucket:
+    !And
+      - !Equals [!Ref ESSnapshotId, ""]
+      - !Not [Condition: ESBucketNameSet]
+  ESBucketNameSet:
+    !Equals [!Ref ESBucketName, ""]
+  StandbyMode:
+    !Not [!Equals [!Ref DBMaster, ""]]
+  SetupSSL:
+    !Not [!Equals [!Ref SSLCertificateName, ""]]
+  NotStandbyMode:
+    !Equals [!Ref DBMaster, ""]
+  IsHomeProvisionedIops:
+    !Equals [!Ref HomeVolumeType, Provisioned IOPS]
+  RestoreRDSOrStandby:
+    !Or [Condition: RestoreFromRDSSnapshot, Condition: StandbyMode]
+  SetDBMasterUserPassword:
+    !And [!Not [!Equals [!Ref DBMasterUserPassword, ""]], Condition: NotStandbyMode]
+Mappings:
+  AWSInstanceType2Arch:
+    c3.large:
+      Arch: HVM64
+    c3.xlarge:
+      Arch: HVM64
+    c3.2xlarge:
+      Arch: HVM64
+    c3.4xlarge:
+      Arch: HVM64
+    c3.8xlarge:
+      Arch: HVM64
+    c4.large:
+      Arch: HVM64
+    c4.xlarge:
+      Arch: HVM64
+    c4.2xlarge:
+      Arch: HVM64
+    c4.4xlarge:
+      Arch: HVM64
+    c4.8xlarge:
+      Arch: HVM64
+    d2.xlarge:
+      Arch: HVM64
+    d2.2xlarge:
+      Arch: HVM64
+    d2.4xlarge:
+      Arch: HVM64
+    d2.8xlarge:
+      Arch: HVM64
+    i2.xlarge:
+      Arch: HVM64
+    i2.2xlarge:
+      Arch: HVM64
+    i2.4xlarge:
+      Arch: HVM64
+    i2.8xlarge:
+      Arch: HVM64
+    m4.large:
+      Arch: HVM64
+    m4.xlarge:
+      Arch: HVM64
+    m4.2xlarge:
+      Arch: HVM64
+    m4.4xlarge:
+      Arch: HVM64
+    m4.10xlarge:
+      Arch: HVM64
+    m4.16xlarge:
+      Arch: HVM64
+    r3.large:
+      Arch: HVM64
+    r3.xlarge:
+      Arch: HVM64
+    r3.2xlarge:
+      Arch: HVM64
+    r3.4xlarge:
+      Arch: HVM64
+    r3.8xlarge:
+      Arch: HVM64
+    x1.32xlarge:
+      Arch: HVM64
+  AWSRegionArch2AMI:
+    ap-northeast-1:
+      HVM64: ami-3652ff57
+      HVMG2: NOT_SUPPORTED
+    ap-northeast-2:
+      HVM64: ami-ca2ffba4
+      HVMG2: NOT_SUPPORTED
+    ap-south-1:
+      HVM64: ami-04a0d46b
+      HVMG2: NOT_SUPPORTED
+    ap-southeast-1:
+      HVM64: ami-8dc464ee
+      HVMG2: NOT_SUPPORTED
+    ap-southeast-2:
+      HVM64: ami-5a053939
+      HVMG2: NOT_SUPPORTED
+    eu-central-1:
+      HVM64: ami-abed16c4
+      HVMG2: NOT_SUPPORTED
+    eu-west-1:
+      HVM64: ami-172d7864
+      HVMG2: NOT_SUPPORTED
+    sa-east-1:
+      HVM64: ami-ef6ef283
+      HVMG2: NOT_SUPPORTED
+    us-east-1:
+      HVM64: ami-609abf77
+      HVMG2: NOT_SUPPORTED
+    us-east-2:
+      HVM64: ami-ea5f058f
+      HVMG2: NOT_SUPPORTED
+    us-west-1:
+      HVM64: ami-ea440e8a
+      HVMG2: NOT_SUPPORTED
+    us-west-2:
+      HVM64: ami-81db7ae1
+      HVMG2: NOT_SUPPORTED
+Resources:
+  BitbucketFileServerRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - "ec2.amazonaws.com"
+                - "es.amazonaws.com"
+            Action: ["sts:AssumeRole"]
+      Path: /
+      Policies:
+        - PolicyName: BitbucketFileServerPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "ec2:AttachVolume"
+                  - "ec2:CopySnapshot"
+                  - "ec2:CreateSnapshot"
+                  - "ec2:CreateTags"
+                  - "ec2:CreateVolume"
+                  - "ec2:DeleteSnapshot"
+                  - "ec2:DescribeInstances"
+                  - "ec2:DescribeSnapshots"
+                  - "ec2:DescribeVolumes"
+                  - "ec2:DetachVolume"
+                  - "rds:AddTagsToResource"
+                  - "rds:CopyDBSnapshot"
+                  - "rds:CreateDBSnapshot"
+                  - "rds:DeleteDBSnapshot"
+                  - "rds:DescribeDBInstances"
+                  - "rds:DescribeDBSnapshots"
+                  - "rds:PromoteReadReplica"
+                  - "rds:ModifyDBInstance"
+                  - "rds:RestoreDBInstanceFromDBSnapshot"
+                  - "iam:PassRole"
+                  - "es:*"
+                Resource: ["*"]
+              - !If
+                - ESBucketNameSet
+                - Effect: Allow
+                  Action:
+                    - "s3:DeleteObject"
+                    - "s3:GetObject"
+                    - "s3:ListBucket"
+                    - "s3:PutObject"
+                  Resource:
+                    - !Sub ["arn:aws:s3:::${BucketName}", BucketName: !Ref ESBucketName]
+                - !Ref "AWS::NoValue"
+  BitbucketClusterNodeRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ec2.amazonaws.com]
+            Action: ["sts:AssumeRole"]
+      Path: /
+      Policies:
+        - PolicyName: BitbucketClusterNodePolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action: ["ec2:DescribeInstances"]
+                Effect: Allow
+                Resource: ["*"]
+  BitbucketFileServerInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Path: /
+      Roles: [!Ref BitbucketFileServerRole]
+  BitbucketClusterNodeInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Path: /
+      Roles: [!Ref BitbucketClusterNodeRole]
+  ClusterNodeGroup:
+    Type: "AWS::AutoScaling::AutoScalingGroup"
+    Properties:
+      DesiredCapacity: !If [StandbyMode, 0, !Ref ClusterNodeMin]
+      LaunchConfigurationName: !Ref ClusterNodeLaunchConfig
+      MaxSize: !Ref ClusterNodeMax
+      MinSize: !If [StandbyMode, 0, !Ref ClusterNodeMin]
+      LoadBalancerNames: [!Ref LoadBalancer]
+      VPCZoneIdentifier: !Ref InternalSubnets
+      Tags:
+        - Key: Name
+          Value: Bitbucket Node
+          PropagateAtLaunch: true
+        - Key: Cluster
+          Value: !Ref "AWS::StackName"
+          PropagateAtLaunch: true
+  ClusterNodeLaunchConfig:
+    Type: "AWS::AutoScaling::LaunchConfiguration"
+    Metadata:
+      AWS::CloudFormation::Init:
+        configSets:
+          default: [1, 2]
+        "1":
+          packages:
+            !If
+              - SetupCollectd
+              - yum:
+                  collectd: []
+                  collectd-java: []
+                  collectd-generic-jmx: []
+                  collectd-rrdtool: []
+              - Ref: "AWS::NoValue"
+          files:
+            /etc/atl:
+              content:
+                !Join
+                  - "\n"
+                  -
+                    - ATL_APP_DATA_MOUNT_ENABLED=false
+                    - !Sub ["ATL_DB_PASSWORD=${DBMasterUserPassword}", DBMasterUserPassword: !Ref DBMasterUserPassword]
+                    - ATL_DB_NAME=bitbucket
+                    - !Sub ["ATL_DB_HOST=${DBEndpointAddress}", DBEndpointAddress: !GetAtt DB.Endpoint.Address]
+                    - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !GetAtt DB.Endpoint.Port]
+                    - ATL_JDBC_DRIVER=org.postgresql.Driver
+                    - !Sub
+                      - "ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/bitbucket"
+                      - DBEndpointAddress: !GetAtt DB.Endpoint.Address
+                        DBEndpointPort: !GetAtt DB.Endpoint.Port
+                    - ATL_JDBC_USER=atlbitbucket
+                    - !Sub ["ATL_JDBC_PASSWORD=${DBPassword}", DBPassword: !Ref DBPassword]
+                    - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}", BitbucketProperties: !Join ["\n", !Ref BitbucketProperties]]
+                    - hazelcast.network.aws=true
+                    - !Sub ["hazelcast.network.aws.iam.role=${BitbucketClusterNodeRole}", BitbucketClusterNodeRole: !Ref BitbucketClusterNodeRole]
+                    - !Sub ["hazelcast.network.aws.region=${Region}", Region: !Ref "AWS::Region"]
+                    - hazelcast.network.aws.tag.key=Cluster
+                    - !Sub ["hazelcast.network.aws.tag.value=${StackName}", StackName: !Ref "AWS::StackName"]
+                    - hazelcast.network.multicast=false
+                    - !Sub ["hazelcast.group.name=${StackName}", StackName: !Ref "AWS::StackName"]
+                    - !Sub ["hazelcast.group.password=${StackName}", StackName: !Ref "AWS::StackName"]
+                    - !Sub ["plugin.search.elasticsearch.aws.region=${Region}", Region: !Ref "AWS::Region"]
+                    - !Sub ["plugin.search.elasticsearch.baseurl=http://${ESEndpoint}\"", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
+                    - !Sub ["ATL_BITBUCKET_VERSION=${BitbucketVersion}", BitbucketVersion: !Ref BitbucketVersion]
+                    - ATL_BITBUCKET_BUNDLED_ELASTICSEARCH_ENABLED=false
+                    - ATL_NGINX_ENABLED=false
+                    - ATL_POSTGRES_ENABLED=false
+                    - !Sub ["ATL_PROXY_NAME=${LoadBalancerDNSName}", LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName]
+                    - ATL_SSL_SELF_CERT_ENABLED=false
+                    - !If [SetupSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]
+                    - !Join ["\n", !Ref AMIOpts]
+            /etc/cfn/cfn-hup.conf:
+              content: !Join
+                - "\n"
+                -
+                  - "[main]"
+                  - !Sub ["stack=${StackId}", StackId: !Ref "AWS::StackId"]
+                  - !Sub ["region=${Region}", Region: !Ref "AWS::Region"]
+              mode: 000400
+              owner: root
+              group: root
+            /etc/cfn/hooks.d/cfn-auto-reloader.conf:
+              content:
+                !Join
+                  - "\n"
+                  -
+                    - "[cfn-auto-reloader-hook]"
+                    - triggers=post.update
+                    - "path=Resources.ClusterNodeLaunchConfig.Metadata.AWS::CloudFormation::Init"
+                    - !Sub
+                      - "action=/opt/aws/bin/cfn-init -v --stack ${StackName} --resource ClusterNodeLaunchConfig --region ${Region}"
+                      - StackName: !Ref "AWS::StackName"
+                        Region: !Ref "AWS::Region"
+                    - runas=root
+            /home/atlbitbucket/.bash_profile:
+              content:
+                !Join
+                  - "\n"
+                  -
+                    - if [ -f ~/.bashrc ]; then
+                    -     . ~/.bashrc
+                    - fi
+                    - !Sub ["export CATALINA_OPTS=\"${CatalinaOpts}\"", CatalinaOpts: !Ref CatalinaOpts]
+              mode: 000644
+              owner: atlbitbucket
+              group: atlbitbucket
+          commands:
+            010_add_nfs_mount:
+              command: !Sub
+                - "echo ${FileServerPrivateIp}:/media/atl/bitbucket/shared /media/atl/bitbucket/shared nfs lookupcache=pos,noatime,intr,rsize=32768,wsize=32768 0 0 >>/etc/fstab"
+                - FileServerPrivateIp: !GetAtt FileServer.PrivateIp
+              ignoreErrors: false
+            020_make_shared_home_dir:
+              command: mkdir -p /media/atl/bitbucket/shared
+              ignoreErrors: false
+            030_chown_shared_home_dir:
+              command: "chown atlbitbucket:atlbitbucket /media/atl/bitbucket /media/atl/bitbucket/shared"
+              ignoreErrors: false
+          services:
+            sysvinit:
+              cfn-hup:
+                enabled: true
+                ensureRunning: true
+                files: [/etc/cfn/cfn-hup.conf, /etc/cfn/hooks.d/cfn-auto-reloader.conf]
+              collectd:
+                !If [SetupCollectd, {enabled: true, ensureRunning: true}, !Ref "AWS::NoValue"]
+              rpcbind:
+                enabled: true
+                ensureRunning: true
+                packages:
+                  yum: [nfs-utils]
+        "2":
+          commands:
+            040_mount_nfs:
+              command: "bash -c \"until mount /media/atl/bitbucket/shared; do echo 'Mount of shared volume failed trying again in 5 seconds.'; sleep 5; done\""
+              ignoreErrors: false
+          services:
+            sysvinit:
+              nfslock:
+                enabled: true
+                ensureRunning: true
+                packages:
+                  yum: [nfs-utils]
+    Properties:
+      AssociatePublicIpAddress: !Ref AssociatePublicIpAddress
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvdf
+          Ebs: {}
+          NoDevice: true
+      KeyName: !Ref KeyName
+      IamInstanceProfile: !Ref BitbucketClusterNodeInstanceProfile
+      ImageId:
+        !FindInMap
+          - AWSRegionArch2AMI
+          - !Ref "AWS::Region"
+          - !FindInMap
+              - AWSInstanceType2Arch
+              - !Ref ClusterNodeInstanceType
+              - Arch
+      InstanceType: !Ref ClusterNodeInstanceType
+      SecurityGroups: [!Ref SecurityGroup]
+      UserData:
+        Fn::Base64:
+          !Join
+            - ""
+            -
+              - "#!/bin/bash -xe\n"
+              - "yum update -y aws-cfn-bootstrap\n"
+              - !Sub ["/opt/aws/bin/cfn-init -v --stack ${StackName}", StackName: !Ref "AWS::StackName"]
+              - !Sub [" --resource ClusterNodeLaunchConfig --region ${Region}\n", Region: !Ref "AWS::Region"]
+              - !Sub ["/opt/aws/bin/cfn-signal -e $? --stack ${StackName}", StackName: !Ref "AWS::StackName"]
+              - !Sub [" --resource ClusterNodeGroup --region ${Region}", Region: !Ref "AWS::Region"]
+  ClusterNodeScaleUpPolicy:
+    Type: "AWS::AutoScaling::ScalingPolicy"
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref ClusterNodeGroup
+      Cooldown: 600
+      ScalingAdjustment: 1
+  ClusterNodeScaleDownPolicy:
+    Type: "AWS::AutoScaling::ScalingPolicy"
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref ClusterNodeGroup
+      Cooldown: 600
+      ScalingAdjustment: -1
+  CPUAlarmHigh:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmDescription: Scale up if CPU > 60% for 5 minutes
+      MetricName: CPUUtilization
+      Namespace: AWS/EC2
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 5
+      Threshold: 60
+      AlarmActions: [!Ref ClusterNodeScaleUpPolicy]
+      Dimensions:
+        - Name: AutoScalingGroupName
+          Value: !Ref ClusterNodeGroup
+      ComparisonOperator: GreaterThanThreshold
+  CPUAlarmLow:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmDescription: Scale down if CPU < 40% for 30 minutes
+      MetricName: CPUUtilization
+      Namespace: AWS/EC2
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 30
+      Threshold: 40
+      AlarmActions: [!Ref ClusterNodeScaleDownPolicy]
+      Dimensions:
+        - Name: AutoScalingGroupName
+          Value: !Ref ClusterNodeGroup
+      ComparisonOperator: LessThanThreshold
+  Elasticsearch:
+    Type: "AWS::Elasticsearch::Domain"
+    Properties:
+      ElasticsearchVersion: 2.3
+      ElasticsearchClusterConfig:
+        InstanceType: !Ref ElasticsearchInstanceType
+      AccessPolicies:
+        Version: 2012-10-17
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !GetAtt BitbucketClusterNodeRole.Arn
+            Action: "es:*"
+            Resource: "*"
+      Tags:
+        - Key: Name
+          Value: Bitbucket Elasticsearch cluster
+        - Key: Application
+          Value: !Ref "AWS::StackId"
+  ElasticsearchBucket:
+    Type: "AWS::S3::Bucket"
+    Condition: CreateESBucket
+    Properties:
+      BucketName: !Ref ESBucketName
+      Tags:
+        - Key: Cluster
+          Value: !Ref "AWS::StackName"
+  ElasticsearchBucketPolicy:
+    Type: "AWS::S3::BucketPolicy"
+    Condition: CreateESBucket
+    Properties:
+      Bucket: !Ref ElasticsearchBucket
+      PolicyDocument:
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !GetAtt BitbucketFileServerRole.Arn
+            Action: ["s3:*"]
+            Resource: !Sub ["arn:aws:s3:::${BucketName}/*", BucketName: !Ref ElasticsearchBucket]
+          - Effect: "Allow"
+            Principal:
+              AWS: !GetAtt BitbucketFileServerRole.Arn
+            Action: ["s3:*"]
+            Resource: !Sub ["arn:aws:s3:::${BucketName}", BucketName: !Ref ElasticsearchBucket]
+  FileServer:
+    Type: "AWS::EC2::Instance"
+    Metadata:
+      Comment: Set up NFS Server and initial bitbucket.properties
+      AWS::CloudFormation::Init:
+        "1":
+          packages:
+            !If
+              - SetupCollectd
+              -
+                yum:
+                  collectd: []
+                  collectd-java: []
+                  collectd-generic-jmx: []
+                  collectd-rrdtool: []
+              - !Ref "AWS::NoValue"
+          files:
+            /etc/atl:
+              content:
+                !Join
+                  - "\n"
+                  -
+                    - ATL_ENABLED_PRODUCTS=
+                    - ATL_ENABLED_SHARED_HOMES=Bitbucket
+                    - ATL_NGINX_ENABLED=false
+                    - ATL_POSTGRES_ENABLED=false
+                    - ATL_SSL_SELF_CERT_ENABLED=false
+                    - ATL_BITBUCKET_BUNDLED_ELASTICSEARCH_ENABLED=false
+                    - ATL_APP_NFS_SERVER=true
+            /etc/cfn/cfn-hup.conf:
+              content:
+                !Join
+                  - "\n"
+                  -
+                    - "[main]"
+                    - !Sub ["stack=${StackId}", StackId: !Ref "AWS::StackId"]
+                    - !Sub ["region=${Region}", Region: !Ref "AWS::Region"]
+              mode: 000400
+              owner: root
+              group: root
+            /etc/cfn/hooks.d/cfn-auto-reloader.conf:
+              content:
+                !Join
+                  - "\n"
+                  -
+                    - "[cfn-auto-reloader-hook]"
+                    - triggers=post.update
+                    - "path=Resources.FileServer.Metadata.AWS::CloudFormation::Init"
+                    - !Sub
+                      - "action=/opt/aws/bin/cfn-init -v --stack ${StackName} --resource FileServer --region ${Region}"
+                      - Region: !Ref "AWS::Region"
+                        StackName: !Ref "AWS::StackName"
+                    - runas=root
+            /opt/atlassian/bitbucket-diy-backup/bitbucket.diy-backup.vars.sh:
+              content:
+                !Join
+                  - "\n"
+                  -
+                    - "# This file was generated from the BitbucketDataCenter CloudFormation template"
+                    - !Sub ["INSTANCE_NAME=${StackName}", StackName: !Ref "AWS::StackName"]
+                    - !Sub
+                      - "BITBUCKET_URL=${HTTP}://${LoadBalancerDNSName}"
+                      - HTTP: !If [SetupSSL, "https", "http"]
+                        LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName
+                    - BITBUCKET_HOME=/media/atl/bitbucket
+                    - BITBUCKET_UID=atlbitbucket
+                    - BITBUCKET_GID=atlbitbucket
+                    - "BACKUP_HOME_TYPE=${BACKUP_HOME_TYPE:-amazon-ebs}"
+                    - "BACKUP_DATABASE_TYPE=${BACKUP_DATABASE_TYPE:-amazon-rds}"
+                    - BACKUP_ARCHIVE_TYPE=
+                    - "BACKUP_ELASTICSEARCH_TYPE=amazon-es"
+                    - "BACKUP_ZERO_DOWNTIME=true"
+                    - HOME_DIRECTORY_MOUNT_POINT=/media/atl
+                    - HOME_DIRECTORY_DEVICE_NAME=/dev/sdf
+                    - !Sub ["RESTORE_HOME_DIRECTORY_VOLUME_TYPE=${HomeProvisionedIops}", HomeProvisionedIops: !If [IsHomeProvisionedIops, "io1", "gp2"]]
+                    - !If [IsHomeProvisionedIops, !Sub ["RESTORE_HOME_DIRECTORY_IOPS=${HomeIops}", HomeIops: !Ref "HomeIops"], !Ref "AWS::NoValue"]
+                    - FILESYSTEM_TYPE=zfs
+                    - "ZFS_HOME_TANK_NAME=$(run sudo zfs list -H -o name,mountpoint | grep \"${HOME_DIRECTORY_MOUNT_POINT}\" | cut -f1)"
+                    - !Sub ["RDS_INSTANCE_ID=${DB}", DB: !Ref "DB"]
+                    - !Sub ["RESTORE_RDS_INSTANCE_CLASS=${DBInstanceClass}", DBInstanceClass: !Ref "DBInstanceClass"]
+                    - !Sub ["RESTORE_RDS_MULTI_AZ=${DBMultiAZ}", DBMultiAZ: !Ref "DBMultiAZ"]
+                    - !Sub ["RESTORE_RDS_SUBNET_GROUP_NAME=${DBSubnetGroup}", DBSubnetGroup: !Ref "DBSubnetGroup"]
+                    - !Sub ["RESTORE_RDS_SECURITY_GROUP=${SecurityGroup}", SecurityGroup: !Ref "SecurityGroup"]
+                    - "CURL_OPTIONS=\"-L -s -f\""
+                    - !Sub ["AWS_REGION=${Region}", Region: !Ref "AWS::Region"]
+                    - "AWS_INFO=$(curl ${CURL_OPTIONS} http://169.254.169.254/latest/dynamic/instance-identity/document)"
+                    - "AWS_ACCOUNT_ID=$(echo \"${AWS_INFO}\" | jq -r .accountId)"
+                    - "AWS_AVAILABILITY_ZONE=$(echo \"${AWS_INFO}\" | jq -r .availabilityZone)"
+                    - "AWS_REGION=$(echo \"${AWS_INFO}\" | jq -r .region)"
+                    - "AWS_EC2_INSTANCE_ID=$(echo \"${AWS_INFO}\" | jq -r .instanceId)"
+                    - AWS_ADDITIONAL_TAGS=
+                    - "BITBUCKET_VERBOSE_BACKUP=${BITBUCKET_VERBOSE_BACKUP:-true}"
+                    - KEEP_BACKUPS=5
+                    - "ELASTICSEARCH_REPOSITORY_NAME=bitbucket-snapshots"
+                    - "ELASTICSEARCH_INDEX_NAME=bitbucket-search-v1"
+                    - !Sub ["ELASTICSEARCH_S3_BUCKET=${BucketName}", BucketName: !Ref ESBucketName]
+                    - !Sub ["ELASTICSEARCH_S3_BUCKET_REGION=${Region}", Region: !Ref "AWS::Region"]
+                    - !Sub ["ELASTICSEARCH_SNAPSHOT_IAM_ROLE=${Role}", Role: !GetAtt BitbucketFileServerRole.Arn]
+                    - !Sub ["ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
+                    - !If
+                      - StandbyMode
+                      - !Sub ["STANDBY_JDBC_URL=jdbc:postgres://${DBEndpointAddress}/bitbucket", DBEndpointAddress: !GetAtt DB.Endpoint.Address]
+                      - !Ref "AWS::NoValue"
+                    - !If
+                      - StandbyMode
+                      - !Sub ["DR_RDS_READ_REPLICA=${DB}", DB: !Ref DB]
+                      - !Ref "AWS::NoValue"
+              mode: 000644
+              owner: "ec2-user"
+              group: "ec2-user"
+          commands:
+            010_pull_diy_backup_repo:
+              command: "git pull"
+              cwd: "/opt/atlassian/bitbucket-diy-backup"
+              ignoreErrors: true
+          services:
+            sysvinit:
+              cfn-hup:
+                enabled: true
+                ensureRunning: true
+                files: [/etc/cfn/cfn-hup.conf, /etc/cfn/hooks.d/cfn-auto-reloader.conf]
+              collectd:
+                !If
+                  - SetupCollectd
+                  - enabled: true
+                    ensureRunning: true
+                  - !Ref "AWS::NoValue"
+              rpcbind:
+                enabled: true
+                ensureRunning: true
+        "2":
+          services:
+            sysvinit:
+              nfs:
+                enabled: true
+                ensureRunning: true
+              nfslock:
+                enabled: true
+                ensureRunning: true
+          commands:
+            !If
+              - RestoreFromESSnapshot
+              - 020_restore_es_snapshot:
+                  command: !Sub
+                    - "/opt/atlassian/bitbucket-diy-backup/bitbucket.diy-restore.sh ${ESSnapshotId}"
+                    - ESSnapshotId: !Ref "ESSnapshotId"
+                  ignoreErrors: false
+                  env:
+                    BACKUP_HOME_TYPE: "none"
+                    BACKUP_DATABASE_TYPE: "none"
+              - !Ref "AWS::NoValue"
+        configSets:
+          default: [1, 2]
+    Properties:
+      BlockDeviceMappings:
+        - DeviceName: /dev/sdf
+          Ebs:
+            VolumeType: !If [IsHomeProvisionedIops, io1, gp2]
+            Iops: !If [IsHomeProvisionedIops, !Ref HomeIops, !Ref "AWS::NoValue"]
+            DeleteOnTermination: !Ref HomeDeleteOnTermination
+            SnapshotId: !If [RestoreFromEBSSnapshot, !Ref HomeVolumeSnapshotId, !Ref "AWS::NoValue"]
+            VolumeSize: !Ref HomeSize
+        - DeviceName: /dev/xvdf
+          NoDevice: {}
+      IamInstanceProfile: !Ref BitbucketFileServerInstanceProfile
+      EbsOptimized: true
+      ImageId:
+        !FindInMap
+          - AWSRegionArch2AMI
+          - !Ref "AWS::Region"
+          - !FindInMap
+              - AWSInstanceType2Arch
+              - !Ref FileServerInstanceType
+              - Arch
+      InstanceType: !Ref FileServerInstanceType
+      KeyName: !Ref KeyName
+      NetworkInterfaces:
+        - GroupSet: [!Ref SecurityGroup]
+          AssociatePublicIpAddress: !Ref AssociatePublicIpAddress
+          DeviceIndex: 0
+          DeleteOnTermination: true
+          SubnetId: !Select [0, !Ref InternalSubnets]
+      Tags:
+        - Key: Name
+          Value: Bitbucket NFS Server
+        - Key: Application
+          Value:
+            !Ref "AWS::StackId"
+      UserData:
+        Fn::Base64:
+          !Join
+            - ""
+            -
+              - "#!/bin/bash -xe\n"
+              - "yum update -y aws-cfn-bootstrap\n"
+              - !Sub ["/opt/aws/bin/cfn-init -v --stack ${StackName}", StackName: !Ref "AWS::StackName"]
+              - !Sub [" --resource FileServer --region ${Region}\n", Region: !Ref "AWS::Region"]
+              - !Sub ["/opt/aws/bin/cfn-signal -e $? --stack ${StackName}", StackName: !Ref "AWS::StackName"]
+              - !Sub [" --resource FileServer --region ${Region}\n", Region: !Ref "AWS::Region"]
+  DB:
+    Type: "AWS::RDS::DBInstance"
+    Properties:
+      SourceDBInstanceIdentifier: !If [StandbyMode, !Ref DBMaster, !Ref "AWS::NoValue"]
+      DBName: !If [RestoreRDSOrStandby, !Ref "AWS::NoValue",bitbucket]
+      AllocatedStorage: !Ref DBStorage
+      DBInstanceClass: !Ref DBInstanceClass
+      DBSnapshotIdentifier: !If [RestoreFromRDSSnapshot, !Ref DBSnapshotId, !Ref "AWS::NoValue"]
+      DBSubnetGroupName: !Ref DBSubnetGroup
+      Engine: postgres
+      EngineVersion: 9.5.2
+      MasterUsername: postgres
+      MasterUserPassword: !If [SetDBMasterUserPassword, !Ref DBMasterUserPassword, !Ref "AWS::NoValue"]
+      StorageType: !If [DBProvisionedIops, io1, gp2]
+      Iops: !If [DBProvisionedIops, !Ref DBIops, !Ref "AWS::NoValue"]
+      MultiAZ: !If [StandbyMode, !Ref "AWS::NoValue", !Ref DBMultiAZ]
+      VPCSecurityGroups: [!Ref SecurityGroup]
+      Tags:
+        - Key: Name
+          Value: Bitbucket PostgreSQL Database
+  DBSubnetGroup:
+    Type: "AWS::RDS::DBSubnetGroup"
+    Properties:
+      DBSubnetGroupDescription: DBSubnetGroup
+      SubnetIds: !Ref InternalSubnets
+  LoadBalancer:
+    Type: "AWS::ElasticLoadBalancing::LoadBalancer"
+    Properties:
+      AppCookieStickinessPolicy:
+        - CookieName: JSESSIONID
+          PolicyName: JSessionIdStickiness
+      ConnectionDrainingPolicy:
+        Enabled: true
+        Timeout: 300
+      ConnectionSettings:
+        IdleTimeout: 3600
+      CrossZone: true
+      Listeners:
+        - LoadBalancerPort: 80
+          Protocol: HTTP
+          InstancePort: !If [SetupSSL, 7991, 7990]
+          InstanceProtocol: HTTP
+          PolicyNames: [JSessionIdStickiness]
+        - !If
+            - SetupSSL
+            - LoadBalancerPort: 443
+              Protocol: HTTPS
+              InstancePort: 7990
+              InstanceProtocol: HTTP
+              PolicyNames:
+                - JSessionIdStickiness
+              SSLCertificateId: !Sub
+                - "arn:aws:iam::${AccountId}:server-certificate/${SSLCertificateName}"
+                - AccountId: !Ref "AWS::AccountId"
+                  SSLCertificateName: !Ref SSLCertificateName
+            - !Ref AWS::NoValue
+        - LoadBalancerPort: 7999
+          Protocol: TCP
+          InstancePort: 7999
+          InstanceProtocol: TCP
+      HealthCheck:
+        Target: HTTP:7990/status
+        Timeout: 29
+        Interval: 30
+        UnhealthyThreshold: 2
+        HealthyThreshold: 2
+      Scheme: "internet-facing"
+      SecurityGroups: [!Ref SecurityGroup]
+      Subnets: !Ref ExternalSubnets
+  SecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: Security group allowing SSH and HTTP/HTTPS access
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: !Ref CidrBlock
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: !Ref CidrBlock
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: !Ref CidrBlock
+        - IpProtocol: tcp
+          FromPort: 7999
+          ToPort: 7999
+          CidrIp: !Ref CidrBlock
+  SecurityGroupIngress:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      GroupId: !Ref SecurityGroup
+      IpProtocol: "-1"
+      FromPort: "-1"
+      ToPort: "-1"
+      SourceSecurityGroupId: !Ref SecurityGroup
+Outputs:
+  ClusterNodeGroup:
+    Description: The name of the auto scaling group of cluster nodes
+    Value: !Ref ClusterNodeGroup
+  FileServer:
+    Description: The public DNS name of the FileServer node
+    Value: !GetAtt FileServer.PublicDnsName
+  URL:
+    Description: The URL of the Bitbucket Data Center instance
+    Value: !Sub
+      - "${HTTP}://${LoadBalancerDNSName}"
+      - HTTP: !If [SetupSSL, "https", "http"]
+        LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName
+  DBMaster:
+    Description: The RDS ARN to use when creating a Data Center standby stack
+    Value: !If [NotStandbyMode, !Sub ["arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:${DB}", {DB: !Ref "DB"}], !Ref "AWS::NoValue"]

--- a/templates/quickstart-bitbucket-master-ap-south.json
+++ b/templates/quickstart-bitbucket-master-ap-south.json
@@ -5,7 +5,7 @@
     },
     {
         "ParameterKey": "BitbucketVersion",
-        "ParameterValue": "4.9.0-rc1"
+        "ParameterValue": "4.11.0"
     },
     {
         "ParameterKey": "DBMasterUserPassword",

--- a/templates/quickstart-bitbucket-master.json
+++ b/templates/quickstart-bitbucket-master.json
@@ -5,7 +5,7 @@
     },
     {
         "ParameterKey": "BitbucketVersion",
-        "ParameterValue": "4.10.0-rc1"
+        "ParameterValue": "4.11.0"
     },
     {
         "ParameterKey": "DBMasterUserPassword",

--- a/templates/quickstart-bitbucket-master.template
+++ b/templates/quickstart-bitbucket-master.template
@@ -291,10 +291,10 @@
       "Default": ""
     },
     "BitbucketVersion": {
-      "Description": "Version of Bitbucket to install, for example: 4.10.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases",
+      "Description": "Version of Bitbucket to install, for example: 4.11.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases",
       "Type": "String",
       "AllowedPattern": "(\\d+\\.\\d+\\.\\d+(-?.*))",
-      "ConstraintDescription": "Must be a valid Bitbucket version number. For example: 4.10.0 or higher"
+      "ConstraintDescription": "Must be a valid Bitbucket version number. For example: 4.11.0 or higher"
     },
     "ClusterNodeMax": {
       "Type": "Number",
@@ -644,6 +644,7 @@
           ]
         },
         "Parameters": {
+          "AMIOpts": "",
           "ExternalSubnets": {
             "Fn::Join": [
               ",",


### PR DESCRIPTION
- Make `BitbucketDataCenter` template YAML
- Update AMI to latest
- Add `AMIOpts` parameter to allow passing custom options to Bitbucket
  AMI;  this parameter is not used for the quickstart

This brings in the current Atlassian Bitbucket Data Center template from [our Bitbucket repo](https://bitbucket.org/atlassian/atlassian-aws-deployment).
Also updated the version suggestion to `4.11.0`, which resolves [an authentication issue (BSERV-9297)](https://jira.atlassian.com/browse/BSERV-9297) with Bitbucket's search indexing when using elasticsearch service.