### PR TITLE
Update AMIs to upgrade Postgres version to 9.6

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -3,6 +3,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: "Atlassian Bitbucket Data Center in new VPC License: Apache 2.0"
 Metadata:
   AWS::CloudFormation::Interface:
+
     ParameterGroups:
       - Label:
           default: Bitbucket setup
@@ -55,7 +56,10 @@ Metadata:
           - StartCollectd
           - QSS3BucketName
           - QSS3KeyPrefix
+
     ParameterLabels:
+      AccessCIDR:
+        default: Trusted IP range
       AMIOpts:
         default: AMI Options
       AvailabilityZones:
@@ -114,6 +118,14 @@ Metadata:
         default: Home volume snapshot ID to restore
       KeyPairName:
         default: Key Name
+      PrivateSubnet1CIDR:
+        default: AZ1 private IP address block
+      PrivateSubnet2CIDR:
+        default: AZ2 private IP address block
+      PublicSubnet1CIDR:
+        default: AZ1 public IP address block        
+      PublicSubnet2CIDR:
+        default: AZ2 public IP address block
       SSLCertificateARN:
         default: SSL Certificate ARN
       StartCollectd:
@@ -122,6 +134,9 @@ Metadata:
         default: Quick Start S3 Bucket Name
       QSS3KeyPrefix:
         default: Quick Start S3 Key Prefix
+      VPCCIDR:
+        default: IP address block for the VPC
+
 Parameters:
   AccessCIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
@@ -295,18 +310,31 @@ Parameters:
     ConstraintDescription: Must be an EC2 instance type from the selection list
     Description: 'Instance type for the cluster application nodes. See https://confluence.atlassian.com/x/GpdKLg for guidance'
     Type: String
-  ClusterNodeMax:
-    Default: 2
-    Type: Number
   ClusterNodeMin:
     Default: 1
     Description: Set to 1 for new deployment. Can be updated post launch.
+    Type: Number
+  ClusterNodeMax:
+    Description: Maximum number of nodes in the cluster.
+    Default: 2
     Type: Number
   CreateBucket:
     Default: true
     AllowedValues: [true, false]
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Set to true to create the S3 bucket within this stack, must be used in conjunction with ESBucketName.
+    Type: String
+  ESBucketName:
+    Default: ''
+    AllowedPattern: '[a-z0-9-]*'
+    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
+    Description: Name of a new, or existing, S3 bucket configured for Elasticsearch snapshots.
+    Type: String
+  ESSnapshotId:
+    Default: ''
+    AllowedPattern: '[a-z0-9-]*'
+    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
+    Description: Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket.
     Type: String
   DBInstanceClass:
     Default: db.m4.large
@@ -346,6 +374,7 @@ Parameters:
     NoEcho: true
     Type: String
   DBMultiAZ:
+    Description: Whether to provision a multi-AZ RDS instance.
     Default: true
     AllowedValues:
       - true
@@ -384,6 +413,7 @@ Parameters:
     Description: Database storage type
     Type: String
   ElasticsearchInstanceType:
+    Description: EC2 instance type for the Amazon Elasticsearch service to run on.
     Type: String
     Default: m4.xlarge.elasticsearch
     AllowedValues:
@@ -398,18 +428,6 @@ Parameters:
       - i2.xlarge.elasticsearch
       - i2.2xlarge.elasticsearch
     ConstraintDescription: Must be an Elasticsearch instance type in the M4, R4 or I2 family
-  ESBucketName:
-    Default: ''
-    AllowedPattern: '[a-z0-9-]*'
-    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
-    Description: Name of a new, or existing, S3 bucket configured for Elasticsearch snapshots.
-    Type: String
-  ESSnapshotId:
-    Default: ''
-    AllowedPattern: '[a-z0-9-]*'
-    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
-    Description: Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket.
-    Type: String
   FileServerInstanceType:
     Default: m4.xlarge
     AllowedValues:
@@ -453,6 +471,7 @@ Parameters:
     Type: String
   HomeVolumeType:
     Default: Provisioned IOPS
+    Description: Bitbucket home storage type.
     AllowedValues: [General Purpose (SSD), Provisioned IOPS]
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Type: String
@@ -467,6 +486,7 @@ Parameters:
     MaxLength: 90
     Type: String
   StartCollectd:
+    Description: Start the 'collectd' metrics agent.
     Default: false
     Type: String
     AllowedValues: [true, false]

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -56,6 +56,7 @@ Metadata:
           - HomeVolumeSnapshotId
           - HomeDeleteOnTermination
           - StartCollectd
+
     ParameterLabels:
       AMIOpts:
         default: AMI Options
@@ -248,6 +249,7 @@ Parameters:
     Description: 'Instance type for the cluster application nodes. See https://confluence.atlassian.com/x/GpdKLg for guidance'
     Type: String
   ClusterNodeMax:
+    Description: Maximum number of nodes in the cluster.
     Default: 2
     Type: Number
   ClusterNodeMin:
@@ -259,6 +261,18 @@ Parameters:
     AllowedValues: [true, false]
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Set to true to create the S3 bucket within this stack, must be used in conjunction with ESBucketName.
+    Type: String
+  ESBucketName:
+    Default: ''
+    AllowedPattern: '[a-z0-9-]*'
+    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
+    Description: Name of a new, or existing, S3 bucket configured for Elasticsearch snapshots.
+    Type: String
+  ESSnapshotId:
+    Default: ''
+    AllowedPattern: '[a-z0-9-]*'
+    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
+    Description: Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket.
     Type: String
   DBInstanceClass:
     Default: db.m4.large
@@ -298,6 +312,7 @@ Parameters:
     NoEcho: true
     Type: String
   DBMultiAZ:
+    Description: Whether to provision a multi-AZ RDS instance.
     Default: true
     AllowedValues:
       - true
@@ -336,6 +351,7 @@ Parameters:
     Description: Database storage type
     Type: String
   ElasticsearchInstanceType:
+    Description: EC2 instance type for the Amazon Elasticsearch service to run on.
     Type: String
     Default: m4.xlarge.elasticsearch
     AllowedValues:
@@ -350,18 +366,6 @@ Parameters:
       - i2.xlarge.elasticsearch
       - i2.2xlarge.elasticsearch
     ConstraintDescription: Must be an Elasticsearch instance type in the M4, R4 or I2 family
-  ESBucketName:
-    Default: ''
-    AllowedPattern: '[a-z0-9-]*'
-    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
-    Description: Name of a new, or existing, S3 bucket configured for Elasticsearch snapshots.
-    Type: String
-  ESSnapshotId:
-    Default: ''
-    AllowedPattern: '[a-z0-9-]*'
-    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
-    Description: Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket.
-    Type: String
   FileServerInstanceType:
     Default: m4.xlarge
     AllowedValues:
@@ -405,6 +409,7 @@ Parameters:
     Type: String
   HomeVolumeType:
     Default: Provisioned IOPS
+    Description: Bitbucket home storage type.
     AllowedValues: [General Purpose (SSD), Provisioned IOPS]
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Type: String
@@ -419,6 +424,7 @@ Parameters:
     MaxLength: 90
     Type: String
   StartCollectd:
+    Description: Start the 'collectd' metrics agent.
     Type: String
     Default: false
     AllowedValues: [true, false]

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -487,35 +487,35 @@ Conditions:
 Mappings:
   AWSRegionArch2AMI:
     ap-northeast-1:
-      HVM64: ami-08ef2026883ad0931
+      HVM64: ami-01cb7136f82407434
     ap-northeast-2:
-      HVM64: ami-0f83fc6f692522bf6
+      HVM64: ami-05939313da2cee1d9
     ap-south-1:
-      HVM64: ami-0177432d41902bdbb
+      HVM64: ami-0f87eb67101adaa95
     ap-southeast-1:
-      HVM64: ami-003849359de4eb3c5
+      HVM64: ami-0f737ef2991410f55
     ap-southeast-2:
-      HVM64: ami-0a7fe660035acdcff
+      HVM64: ami-0f880c612ba9db684
     ca-central-1:
-      HVM64: ami-03a3c1d6650658e9d
+      HVM64: ami-07f9b76d33830f1aa
     eu-central-1:
-      HVM64: ami-00f22060e5c39cb89
+      HVM64: ami-02f390185bddcfb01
     eu-west-1:
-      HVM64: ami-0955f4b496f860cd9
+      HVM64: ami-050e8cd830aa9ed94
     eu-west-2:
-      HVM64: ami-07d018490aadc8077
+      HVM64: ami-0a48a64baf846b803
     eu-west-3:
-      HVM64: ami-0f45279ed791b6e4a
+      HVM64: ami-0b6f8672aec4fee91
     sa-east-1:
-      HVM64: ami-0065d07493984a78b
+      HVM64: ami-0b37b97b0afa89d88
     us-east-1:
-      HVM64: ami-007d583e51592b28f
+      HVM64: ami-05bf747bde497cacd
     us-east-2:
-      HVM64: ami-0d7e93975ebbe565e
+      HVM64: ami-00de6870b0710223e
     us-west-1:
-      HVM64: ami-0ff59c7466487df7c
+      HVM64: ami-0e3184ec65584b002
     us-west-2:
-      HVM64: ami-0ccfb450bced77082
+      HVM64: ami-05653cd3cf9f4ad7c
 Resources:
   BitbucketFileServerRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
We decommissioned Postgres 9.3 in Bitbucket Server 6.x (about to be released soon), but the AMIs still had the Postgres version set to 9.3 so our templates won't work with BbS 6.0 and above. This change upgrades the Postgres version to 9.6.