### PR TITLE
DCD-386: Convert Quickstart to use Amazon AMIs and Ansible-based node deployment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Use this Quick Start to deploy Bitbucket Data Center on the AWS Cloud. Bitbucket
 
 This Quick Start uses the [Atlassian Standard Infrastructure (ASI)](https://fwd.aws/xYyYy) as a foundation. You can choose to build a new ASI for your deployment or deploy Bitbucket into your existing ASI. You can also deploy Jira and Confluence Data Center within the same ASI.
 
-![Quick Start architecture for Bitbucket on AWS](https://d0.awsstatic.com/partner-network/QuickStart/datasheets/bitbucket-on-aws-architecture.png)
+![Quick Start architecture for Bitbucket on AWS](https://d1.awsstatic.com/partner-network/QuickStart/datasheets/bitbucket-on-aws-architecture.630a7271e53cd286bf2af5cbfb93cde9d0ba5e65.png)
 
 For architectural details, best practices, step-by-step instructions, and customization options, see the 
 [deployment guide](https://fwd.aws/dEX6W).


### PR DESCRIPTION
This PR converts the Quickstart to use the official Amazon Linux 2 AMIs. All post-installation application configuration is now handled by external Ansible roles & playbooks. The Ansible repository is here:

    https://bitbucket.org/atlassian/dc-deployments-automation/src/master/

The use of official AMIs is common request from organisations that have restrictions on which AMIs they can use, and the separation of infrastructure and application configuration should increase flexibility, development speed, and simplify security updates to AMIs.

This also removes a number of unused and obsolete parameters, while adding parameters to customise the initialisation repository.