### PR TITLE
Update AssociatePublicIPAddress parameter

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -202,10 +202,6 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     Description: CIDR Block for the VPC
     Type: String
-  AMIOpts:
-    Default: ''
-    Description: A comma separated list of options to pass to the AMI
-    Type: CommaDelimitedList
   BitbucketProperties:
     Default: ''
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
@@ -558,9 +554,6 @@ Resources:
             - s3-us-gov-west-1
             - s3
       Parameters:
-        AMIOpts: !Join
-          - ','
-          - !Ref 'AMIOpts'
         InternetFacingLoadBalancer: !Ref 'InternetFacingLoadBalancer'
         BitbucketProperties: !Join
           - ','

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -15,7 +15,7 @@ Metadata:
           - AccessCIDR
           - VPCCIDR
           - AvailabilityZones
-          - AssociatePublicIpAddress
+          - InternetFacingLoadBalancer
           - CustomDnsName
           - SSLCertificateARN
           - PrivateSubnet1CIDR
@@ -66,8 +66,6 @@ Metadata:
         default: Trusted IP range
       AvailabilityZones:
         default: Availability Zones
-      AssociatePublicIpAddress:
-        default: Assign public IP
       BitbucketProperties:
         default: Bitbucket properties
       BitbucketVersion:
@@ -128,6 +126,8 @@ Metadata:
         default: Home directory size
       HomeVolumeSnapshotId:
         default: Home volume snapshot ID to restore
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
       KeyPairName:
         default: Key Name
       PrivateSubnet1CIDR:
@@ -202,12 +202,10 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     Description: CIDR Block for the VPC
     Type: String
-  AssociatePublicIpAddress:
-    Default: true
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the EC2 instances are assigned a public IP address
-    Type: String
+  AMIOpts:
+    Default: ''
+    Description: A comma separated list of options to pass to the AMI
+    Type: CommaDelimitedList
   BitbucketProperties:
     Default: ''
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
@@ -507,6 +505,12 @@ Parameters:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances
     Type: AWS::EC2::KeyPair::KeyName
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
+    Type: String
   CustomDnsName:
     Default: ""
     Description: 'Use custom existing DNS name for your Data Center instance. Please note: you must own the domain and configure it to point at the load balancer.'
@@ -554,7 +558,10 @@ Resources:
             - s3-us-gov-west-1
             - s3
       Parameters:
-        AssociatePublicIpAddress: !Ref 'AssociatePublicIpAddress'
+        AMIOpts: !Join
+          - ','
+          - !Ref 'AMIOpts'
+        InternetFacingLoadBalancer: !Ref 'InternetFacingLoadBalancer'
         BitbucketProperties: !Join
           - ','
           - !Ref 'BitbucketProperties'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -38,8 +38,8 @@ Metadata:
       - Label:
           default: Networking
         Parameters:
-          - AssociatePublicIpAddress
           - CidrBlock
+          - InternetFacingLoadBalancer
           - KeyPairName
           - CustomDnsName
           - SSLCertificateARN
@@ -62,8 +62,6 @@ Metadata:
           - DeploymentAutomationKeyName
 
     ParameterLabels:
-      AssociatePublicIpAddress:
-        default: Assign public IP
       BitbucketProperties:
         default: Bitbucket properties
       BitbucketVersion:
@@ -126,6 +124,8 @@ Metadata:
         default: Home volume snapshot ID to restore
       HomeVolumeType:
         default: Home directory volume type
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
       KeyPairName:
         default: Key Name *
       CustomDnsName:
@@ -134,12 +134,6 @@ Metadata:
         default: SSL Certificate ARN
 
 Parameters:
-  AssociatePublicIpAddress:
-    Default: true
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the EC2 instances are assigned a public IP address
-    Type: String
   BitbucketProperties:
     Default: ''
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
@@ -446,6 +440,12 @@ Parameters:
     AllowedValues: [General Purpose (SSD), Provisioned IOPS]
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Type: String
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
+    Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances
@@ -515,7 +515,7 @@ Conditions:
   SetDBMasterUserPassword:
     !And [!Not [!Equals [!Ref DBMasterUserPassword, '']], Condition: NotStandbyMode]
   UsePublicIp:
-    !Equals [!Ref AssociatePublicIpAddress, 'true']
+    !Equals [!Ref InternetFacingLoadBalancer, 'true']
 
 Mappings:
   AWSRegionArch2AMI:


### PR DESCRIPTION
Change AssociatePublicIPAddress parameter to InternetFacingLoadBalancer and update description so it is less misleading

We had reports of customers not being able to access their instance because they set AssociatePublicIPAddress to false, thinking it would make their EC2 instances publicly accessible if it were true. In reality it just controls the load balancer scheme.