### PR TITLE
DCD-595: Add default taskcat build and fix EBS VolumeType & password quoting

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,7 @@
+templates:
+  - templates/*
+ignore_checks:
+  - E2504
+    # The check cannot handle this situation:
+    # Iops: !If [IsHomeProvisionedIops, !Ref HomeIops, !Ref "AWS::NoValue"]
+    # VolumeType: !If [IsHomeProvisionedIops, io1, gp2]

--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -1,0 +1,34 @@
+[
+  {
+    "ParameterKey": "DBMultiAZ",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "BitbucketVersion",
+    "ParameterValue": "6.6.0"
+  },
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "f925dO1ry_"
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "0.0.0.0/0"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.t2.large"
+  },
+  {
+    "ParameterKey": "DBIops",
+    "ParameterValue": "1000"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "f925dO1ry_"
+  },
+  {
+    "ParameterKey": "KeyPairName",
+    "ParameterValue": "replaced-by-taskcat-override-file"
+  }
+]

--- a/ci/params/default/taskcat.yml
+++ b/ci/params/default/taskcat.yml
@@ -1,0 +1,26 @@
+---
+global:
+  qsname: quickstart-atlassian-bitbucket
+  owner: quickstart-eng@amazon.com
+  marketplace-ami: false
+  reporting: true
+  regions:
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - eu-central-1
+    - eu-west-1
+    - sa-east-1
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+
+tests:
+  BB-5:
+    template_file: quickstart-bitbucket-dc.template.yaml
+    parameter_input: params/default/quickstart-bitbucket-default.json
+    regions:
+     - us-east-1

--- a/ci/quickstart-bitbucket-master-v5.json
+++ b/ci/quickstart-bitbucket-master-v5.json
@@ -5,11 +5,11 @@
     },
     {
         "ParameterKey": "BitbucketVersion",
-        "ParameterValue": "5.16.0"
+        "ParameterValue": "6.6.0"
     },
     {
         "ParameterKey": "DBMasterUserPassword",
-        "ParameterValue": "$[taskcat_genpass_8]"
+        "ParameterValue": "f925dO1ry_"
     },
     {
         "ParameterKey": "AccessCIDR",
@@ -25,7 +25,7 @@
     },
     {
         "ParameterKey": "DBPassword",
-        "ParameterValue": "$[taskcat_genpass_8]"
+        "ParameterValue": "f925dO1ry_"
     },
     {
         "ParameterKey": "KeyPairName",

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -52,7 +52,6 @@ Metadata:
           - BitbucketProperties
           - JvmHeapOverride
           - JvmSupportOpts
-          - AMIOpts
           - HomeDeleteOnTermination
           - DBMaster
           - DeploymentAutomationRepository
@@ -65,8 +64,6 @@ Metadata:
     ParameterLabels:
       AccessCIDR:
         default: Trusted IP range
-      AMIOpts:
-        default: AMI Options
       AvailabilityZones:
         default: Availability Zones
       AssociatePublicIpAddress:
@@ -205,10 +202,6 @@ Parameters:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     Description: CIDR Block for the VPC
     Type: String
-  AMIOpts:
-    Default: ''
-    Description: A comma separated list of options to pass to the AMI
-    Type: CommaDelimitedList
   AssociatePublicIpAddress:
     Default: true
     AllowedValues: [true, false]
@@ -561,9 +554,6 @@ Resources:
             - s3-us-gov-west-1
             - s3
       Parameters:
-        AMIOpts: !Join
-          - ','
-          - !Ref 'AMIOpts'
         AssociatePublicIpAddress: !Ref 'AssociatePublicIpAddress'
         BitbucketProperties: !Join
           - ','

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -135,7 +135,7 @@ Metadata:
       PrivateSubnet2CIDR:
         default: AZ2 private IP address block
       PublicSubnet1CIDR:
-        default: AZ1 public IP address block        
+        default: AZ1 public IP address block
       PublicSubnet2CIDR:
         default: AZ2 public IP address block
       CustomDnsName:
@@ -388,12 +388,12 @@ Parameters:
     MaxValue: 30000
     Type: Number
   DBMasterUserPassword:
-    AllowedPattern: '[a-zA-Z0-9]*'
-    ConstraintDescription: Must be at least 8 alphanumeric characters.
-    Description: Password for the master ('postgres') account.
-    MinLength: 8
+    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
+    ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    Description: Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    NoEcho: True
     MaxLength: 128
-    NoEcho: true
+    MinLength: 8
     Type: String
   DBMultiAZ:
     Description: Whether to provision a multi-AZ RDS instance.
@@ -404,9 +404,9 @@ Parameters:
     ConstraintDescription: Must be 'true' or 'false'.
     Type: String
   DBPassword:
-    AllowedPattern: '[a-zA-Z0-9]*'
-    ConstraintDescription: If specified, must be at least 8 alphanumeric characters.
-    Description: Password for the Bitbucket user ('atlbitbucket') account. Max length of 128 characters. Not used if you have specified a Database snapshot ID.
+    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
+    ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    Description: Password for the Bitbucket user ('atlbitbucket') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
     MaxLength: 128
     NoEcho: true
     Type: String
@@ -566,6 +566,7 @@ Resources:
         ClusterNodeMax: !Ref 'ClusterNodeMax'
         ClusterNodeMin: !Ref 'ClusterNodeMin'
         CreateBucket: !Ref 'CreateBucket'
+        CustomDnsName: !Ref 'CustomDnsName'
         DBInstanceClass: !Ref 'DBInstanceClass'
         DBIops: !Ref 'DBIops'
         DBMasterUserPassword: !Ref 'DBMasterUserPassword'

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -53,7 +53,10 @@ Metadata:
           - AMIOpts
           - HomeDeleteOnTermination
           - DBMaster
-          - StartCollectd
+          - DeploymentAutomationRepository
+          - DeploymentAutomationBranch
+          - DeploymentAutomationPlaybook
+          - DeploymentAutomationKeyName
           - QSS3BucketName
           - QSS3KeyPrefix
 
@@ -80,6 +83,14 @@ Metadata:
         default: Bitbucket cluster node instance type
       CreateBucket:
         default: Create S3 bucket for Elasticsearch snapshots
+      DeploymentAutomationRepository:
+        default: Deployment Automation Git Repository URL
+      DeploymentAutomationBranch:
+        default: Deployment Automation Branch
+      DeploymentAutomationPlaybook:
+        default: The Ansible playbook to invoke to initialise the instance.
+      DeploymentAutomationKeyName:
+        default: SSH keyname to use with the repository (Optional)
       ESBucketName:
         default: Elasticsearch snapshot S3 bucket name
       ESSnapshotId:
@@ -128,8 +139,6 @@ Metadata:
         default: AZ2 public IP address block
       SSLCertificateARN:
         default: SSL Certificate ARN
-      StartCollectd:
-        default: Start the collectd service
       QSS3BucketName:
         default: Quick Start S3 Bucket Name
       QSS3KeyPrefix:
@@ -324,6 +333,22 @@ Parameters:
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Set to true to create the S3 bucket within this stack, must be used in conjunction with ESBucketName.
     Type: String
+  DeploymentAutomationRepository:
+    Default: 'https://bitbucket.org/atlassian/dc-deployments-automation.git'
+    Type: String
+    Description: The deployment automation repository to use for per-node initialisation. Leave this as default unless you have customisations.
+  DeploymentAutomationBranch:
+    Default: "master"
+    Type: String
+    Description: The deployment automation repository branch to pull from.
+  DeploymentAutomationPlaybook:
+    Default: "aws_bitbucket_dc_node.yml"
+    Type: String
+    Description: The Ansible playbook to invoke to initialise the application node on first start.
+  DeploymentAutomationKeyName:
+    Default: ""
+    Type: String
+    Description: Named KeyPair name to use with this repository. The key should be imported into the SSM parameter store. (Optional)
   ESBucketName:
     Default: ''
     AllowedPattern: '[a-z0-9-]*'
@@ -485,12 +510,7 @@ Parameters:
     MinLength: 0
     MaxLength: 90
     Type: String
-  StartCollectd:
-    Description: Start the 'collectd' metrics agent.
-    Default: false
-    Type: String
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'
+
 Conditions:
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
@@ -550,6 +570,10 @@ Resources:
         DBSnapshotId: !Ref 'DBSnapshotId'
         DBStorage: !Ref 'DBStorage'
         DBStorageType: !Ref 'DBStorageType'
+        DeploymentAutomationRepository: !Ref 'DeploymentAutomationRepository'
+        DeploymentAutomationBranch: !Ref 'DeploymentAutomationBranch'
+        DeploymentAutomationPlaybook: !Ref 'DeploymentAutomationPlaybook'
+        DeploymentAutomationKeyName: !Ref 'DeploymentAutomationKeyName'
         ElasticsearchInstanceType: !Ref 'ElasticsearchInstanceType'
         ESBucketName: !Ref 'ESBucketName'
         ESSnapshotId: !Ref 'ESSnapshotId'
@@ -561,7 +585,7 @@ Resources:
         HomeVolumeType: !Ref 'HomeVolumeType'
         KeyPairName: !Ref 'KeyPairName'
         SSLCertificateARN: !Ref 'SSLCertificateARN'
-        StartCollectd: !Ref 'StartCollectd'
+
 Outputs:
   ClusterNodeGroup:
     Description: The name of the auto scaling group of cluster nodes

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -16,6 +16,7 @@ Metadata:
           - VPCCIDR
           - AvailabilityZones
           - AssociatePublicIpAddress
+          - CustomDnsName
           - SSLCertificateARN
           - PrivateSubnet1CIDR
           - PrivateSubnet2CIDR
@@ -49,7 +50,8 @@ Metadata:
           - ESBucketName
           - ESSnapshotId
           - BitbucketProperties
-          - CatalinaOpts
+          - JvmHeapOverride
+          - JvmSupportOpts
           - AMIOpts
           - HomeDeleteOnTermination
           - DBMaster
@@ -73,8 +75,10 @@ Metadata:
         default: Bitbucket properties
       BitbucketVersion:
         default: Version
-      CatalinaOpts:
-        default: Catalina options
+      JvmHeapOverride:
+        default: JVM Heap Size Override
+      JvmSupportOpts:
+        default: Additional JVM options
       ClusterNodeMax:
         default: Maximum number of cluster nodes
       ClusterNodeMin:
@@ -137,6 +141,8 @@ Metadata:
         default: AZ1 public IP address block        
       PublicSubnet2CIDR:
         default: AZ2 public IP address block
+      CustomDnsName:
+        default: Existing DNS name (optional)
       SSLCertificateARN:
         default: SSL Certificate ARN
       QSS3BucketName:
@@ -219,9 +225,13 @@ Parameters:
     ConstraintDescription: 'Must be a valid Bitbucket version number. For example: 5.0.0 or higher'
     Description: 'Version of Bitbucket to install. Please use version 5.0.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases'
     Type: String
-  CatalinaOpts:
+  JvmHeapOverride:
     Default: ''
-    Description: Pass in any additional JVM options to tune Catalina Tomcat
+    Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g
+    Type: String
+  JvmSupportOpts:
+    Default: ''
+    Description: Pass in any additional JVM options to tune the Bitbucket instance
     Type: String
   ClusterNodeInstanceType:
     Default: c5.xlarge
@@ -504,6 +514,10 @@ Parameters:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances
     Type: AWS::EC2::KeyPair::KeyName
+  CustomDnsName:
+    Default: ""
+    Description: 'Use custom existing DNS name for your Data Center instance. Please note: you must own the domain and configure it to point at the load balancer.'
+    Type: String
   SSLCertificateARN:
     Default: ''
     Description: Amazon Resource Name (ARN) of your SSL certificate. If you want to use your own certificate that you generated outside of Amazon, you need to first import it to AWS Certificate Manager. After a successful import, you'll receive the ARN. If you want to create a certificate with AWS Certificate Manager (ACM certificate), you will receive the ARN after it's successfully created.
@@ -555,7 +569,8 @@ Resources:
           - ','
           - !Ref 'BitbucketProperties'
         BitbucketVersion: !Ref 'BitbucketVersion'
-        CatalinaOpts: !Ref 'CatalinaOpts'
+        JvmHeapOverride: !Ref 'JvmHeapOverride'
+        JvmSupportOpts: !Ref 'JvmSupportOpts'
         CidrBlock: !Ref 'AccessCIDR'
         ClusterNodeInstanceType: !Ref 'ClusterNodeInstanceType'
         ClusterNodeMax: !Ref 'ClusterNodeMax'

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -15,7 +15,7 @@ Metadata:
           - AccessCIDR
           - VPCCIDR
           - AvailabilityZones
-          - AssociatePublicIpAddress
+          - InternetFacingLoadBalancer
           - CustomDnsName
           - SSLCertificateARN
           - PrivateSubnet1CIDR
@@ -66,8 +66,6 @@ Metadata:
         default: Trusted IP range
       AvailabilityZones:
         default: Availability Zones
-      AssociatePublicIpAddress:
-        default: Assign public IP
       BitbucketProperties:
         default: Bitbucket properties
       BitbucketVersion:
@@ -128,6 +126,8 @@ Metadata:
         default: Home directory size
       HomeVolumeSnapshotId:
         default: Home volume snapshot ID to restore
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
       KeyPairName:
         default: Key Name
       PrivateSubnet1CIDR:
@@ -201,12 +201,6 @@ Parameters:
     Default: 10.0.0.0/16
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
     Description: CIDR Block for the VPC
-    Type: String
-  AssociatePublicIpAddress:
-    Default: true
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the EC2 instances are assigned a public IP address
     Type: String
   BitbucketProperties:
     Default: ''
@@ -507,6 +501,12 @@ Parameters:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances
     Type: AWS::EC2::KeyPair::KeyName
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
+    Type: String
   CustomDnsName:
     Default: ""
     Description: 'Use custom existing DNS name for your Data Center instance. Please note: you must own the domain and configure it to point at the load balancer.'
@@ -554,7 +554,7 @@ Resources:
             - s3-us-gov-west-1
             - s3
       Parameters:
-        AssociatePublicIpAddress: !Ref 'AssociatePublicIpAddress'
+        InternetFacingLoadBalancer: !Ref 'InternetFacingLoadBalancer'
         BitbucketProperties: !Join
           - ','
           - !Ref 'BitbucketProperties'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -291,12 +291,6 @@ Parameters:
     Default: ""
     Type: String
     Description: Named KeyPair name to use with this repository. The key should be imported into the SSM parameter store. (Optional)
-  ESBucketName:
-    Default: ''
-    AllowedPattern: '[a-z0-9-]*'
-    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
-    Description: Name of a new, or existing, S3 bucket configured for Elasticsearch snapshots.
-    Type: String
   ESSnapshotId:
     Default: ''
     AllowedPattern: '[a-z0-9-]*'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -45,7 +45,6 @@ Metadata:
       - Label:
           default: Advanced (Optional)
         Parameters:
-          - AMIOpts
           - BitbucketProperties
           - CatalinaOpts
           - CreateBucket
@@ -55,11 +54,12 @@ Metadata:
           - ESSnapshotId
           - HomeVolumeSnapshotId
           - HomeDeleteOnTermination
-          - StartCollectd
+          - DeploymentAutomationRepository
+          - DeploymentAutomationBranch
+          - DeploymentAutomationPlaybook
+          - DeploymentAutomationKeyName
 
     ParameterLabels:
-      AMIOpts:
-        default: AMI Options
       AssociatePublicIpAddress:
         default: Assign public IP
       BitbucketProperties:
@@ -96,6 +96,14 @@ Metadata:
         default: Database storage type
       DBSnapshotId:
         default: Database snapshot ID to restore
+      DeploymentAutomationRepository:
+        default: Deployment Automation Git Repository URL
+      DeploymentAutomationBranch:
+        default: Deployment Automation Branch
+      DeploymentAutomationPlaybook:
+        default: The Ansible playbook to invoke to initialise the instance.
+      DeploymentAutomationKeyName:
+        default: SSH keyname to use with the repository (Optional)
       ElasticsearchInstanceType:
         default: Elasticsearch instance type
       ESBucketName:
@@ -118,13 +126,8 @@ Metadata:
         default: Key Name *
       SSLCertificateARN:
         default: SSL Certificate ARN
-      StartCollectd:
-        default: Start the collectd service
+
 Parameters:
-  AMIOpts:
-    Default: ''
-    Description: A comma separated list of options to pass to the AMI
-    Type: CommaDelimitedList
   AssociatePublicIpAddress:
     Default: true
     AllowedValues: [true, false]
@@ -136,7 +139,7 @@ Parameters:
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
     Type: CommaDelimitedList
   BitbucketVersion:
-    Default: 6.0.0
+    Default: 6.3.1
     AllowedPattern: '([^1234]\.\d+\.\d+(-?.*))'
     ConstraintDescription: 'Must be a valid Bitbucket version number. For example: 5.0.0 or higher'
     Description: 'Version of Bitbucket to install. Please use version 5.0.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases'
@@ -261,6 +264,34 @@ Parameters:
     AllowedValues: [true, false]
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Set to true to create the S3 bucket within this stack, must be used in conjunction with ESBucketName.
+    Type: String
+  DeploymentAutomationRepository:
+    Default: 'https://bitbucket.org/atlassian/dc-deployments-automation.git'
+    Type: String
+    Description: The deployment automation repository to use for per-node initialisation. Leave this as default unless you have customisations.
+  DeploymentAutomationBranch:
+    Default: "master"
+    Type: String
+    Description: The deployment automation repository branch to pull from.
+  DeploymentAutomationPlaybook:
+    Default: "aws_bitbucket_dc_node.yml"
+    Type: String
+    Description: The Ansible playbook to invoke to initialise the application node on first start.
+  DeploymentAutomationKeyName:
+    Default: ""
+    Type: String
+    Description: Named KeyPair name to use with this repository. The key should be imported into the SSM parameter store. (Optional)
+  ESBucketName:
+    Default: ''
+    AllowedPattern: '[a-z0-9-]*'
+    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
+    Description: Name of a new, or existing, S3 bucket configured for Elasticsearch snapshots.
+    Type: String
+  ESSnapshotId:
+    Default: ''
+    AllowedPattern: '[a-z0-9-]*'
+    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
+    Description: Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket.
     Type: String
   DBInstanceClass:
     Default: db.m4.large
@@ -427,17 +458,10 @@ Parameters:
     MinLength: 0
     MaxLength: 90
     Type: String
-  StartCollectd:
-    Description: Start the 'collectd' metrics agent.
-    Type: String
-    Default: false
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'
+
 Conditions:
   DBProvisionedIops:
     !Equals [!Ref DBStorageType, Provisioned IOPS]
-  SetupCollectd:
-    !Equals [!Ref StartCollectd, true]
   RestoreFromEBSSnapshot:
     !Not [!Equals [!Ref HomeVolumeSnapshotId, '']]
   RestoreFromRDSSnapshot:
@@ -488,38 +512,58 @@ Conditions:
     !And [!Not [!Equals [!Ref DBMasterUserPassword, '']], Condition: NotStandbyMode]
   UsePublicIp:
     !Equals [!Ref AssociatePublicIpAddress, 'true']
+
 Mappings:
   AWSRegionArch2AMI:
     ap-northeast-1:
-      HVM64: ami-07ff8945520f92958
+      HVM64: ami-0c3fd0f5d33134a76
+      HVMG2: NOT_SUPPORTED
     ap-northeast-2:
-      HVM64: ami-0396030a1aa9d137a
+      HVM64: ami-095ca789e0549777d
+      HVMG2: NOT_SUPPORTED
     ap-south-1:
-      HVM64: ami-04660402515df493d
+      HVM64: ami-0d2692b6acea72ee6
+      HVMG2: NOT_SUPPORTED
     ap-southeast-1:
-      HVM64: ami-0a2eecc626a832214
+      HVM64: ami-01f7527546b557442
+      HVMG2: NOT_SUPPORTED
     ap-southeast-2:
-      HVM64: ami-0f249e70c4604d120
+      HVM64: ami-0dc96254d5535925f
+      HVMG2: NOT_SUPPORTED
     ca-central-1:
-      HVM64: ami-0b8aadaca57a6d5e7
+      HVM64: ami-0d4ae09ec9361d8ac
+      HVMG2: NOT_SUPPORTED
     eu-central-1:
-      HVM64: ami-0946d2bfdcabd0165
+      HVM64: ami-0cc293023f983ed53
+      HVMG2: NOT_SUPPORTED
+    eu-north-1:
+      HVM64: ami-3f36be41
+      HVMG2: NOT_SUPPORTED
     eu-west-1:
-      HVM64: ami-0253fbd6b64b72c1b
+      HVM64: ami-0bbc25e23a7640b9b
+      HVMG2: NOT_SUPPORTED
     eu-west-2:
-      HVM64: ami-0b6af558ccec96893
+      HVM64: ami-0d8e27447ec2c8410
+      HVMG2: NOT_SUPPORTED
     eu-west-3:
-      HVM64: ami-0eb93afe8c49e6457
+      HVM64: ami-0adcddd3324248c4c
+      HVMG2: NOT_SUPPORTED
     sa-east-1:
-      HVM64: ami-0e3b98c8d64663239
+      HVM64: ami-058943e7d9b9cabfb
+      HVMG2: NOT_SUPPORTED
     us-east-1:
-      HVM64: ami-0a6bd01ca6be004ea
+      HVM64: ami-0b898040803850657
+      HVMG2: NOT_SUPPORTED
     us-east-2:
-      HVM64: ami-0eff2569bf0eb6486
+      HVM64: ami-0d8f6eb4f641ef691
+      HVMG2: NOT_SUPPORTED
     us-west-1:
-      HVM64: ami-05db3ed23141c46a2
+      HVM64: ami-056ee704806822732
+      HVMG2: NOT_SUPPORTED
     us-west-2:
-      HVM64: ami-0bc936a057671989b
+      HVM64: ami-082b5a644766e0e6f
+      HVMG2: NOT_SUPPORTED
+
 Resources:
   BitbucketFileServerRole:
     Type: AWS::IAM::Role
@@ -628,131 +672,96 @@ Resources:
     Type: AWS::AutoScaling::LaunchConfiguration
     Metadata:
       AWS::CloudFormation::Init:
-        configSets:
-          default: [1, 2]
-        '1':
-          packages:
-            !If
-            - SetupCollectd
-            - yum:
-                collectd: []
-                collectd-java: []
-                collectd-generic-jmx: []
-                collectd-rrdtool: []
-            - !Ref AWS::NoValue
+        config:
           files:
             /etc/atl:
               content:
                 !Join
                 - "\n"
                 -
-                  - ATL_APP_DATA_MOUNT_ENABLED=false
-                  - !Sub ["ATL_DB_PASSWORD=${DBMasterUserPassword}", DBMasterUserPassword: !Ref DBMasterUserPassword]
-                  - ATL_DB_NAME=bitbucket
+                  - "ATL_PRODUCT=bitbucket"
+                  - "ATL_APP_DATA_MOUNT_ENABLED=false"
+                  - ""
+                  - !Sub ["ATL_PRODUCT_VERSION=${BitbucketVersion}", BitbucketVersion: !Ref BitbucketVersion]
+                  - !Sub ["ATL_PROXY_NAME=${LoadBalancerDNSName}", LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName]
+                  - !Sub ["ATL_FILESERVER_IP=${FileServerPrivateIp}", FileServerPrivateIp: !GetAtt FileServer.PrivateIp]
+                  - !Sub ["ATL_DEPLOYMENT_REPOSITORY=${DeployRepository}", DeployRepository: !Ref "DeploymentAutomationRepository"]
+                  - !Sub ["ATL_DEPLOYMENT_REPOSITORY_BRANCH=${DeployRepositoryBranch}", DeployRepositoryBranch: !Ref "DeploymentAutomationBranch"]
+                  - !Sub ["ATL_DEPLOYMENT_REPOSITORY_PLAYBOOK=${DeployRepositoryPlaybook}", DeployRepositoryPlaybook: !Ref "DeploymentAutomationPlaybook"]
+                  - !Sub ["ATL_DEPLOYMENT_REPOSITORY_KEYNAME=${DeployRepositoryKeyName}", DeployRepositoryKeyName: !Ref "DeploymentAutomationKeyName"]
+                  - ""
+                  - !Sub ["ATL_AWS_REGION=${Region}", Region: !Ref "AWS::Region"]
+                  - !Sub ["ATL_AWS_STACK_NAME=${StackName}", StackName: !Ref "AWS::StackName"]
+                  - !Sub ["ATL_AWS_IAM_ROLE=${Role}", Role: !Ref BitbucketClusterNodeRole]
+                  - !Sub ["ATL_AWS_IAM_ROLE_ARN=${Role}", Role: !GetAtt BitbucketFileServerRole.Arn]
+                  - ""
+                  - "ATL_JDBC_DB_NAME=bitbucket"
+                  - "ATL_JDBC_DRIVER=org.postgresql.Driver"
+                  - "ATL_JDBC_USER=atlbitbucket"
+                  - !Sub ["ATL_JDBC_PASSWORD=${DBPassword}", DBPassword: !Ref DBPassword]
+                  - !Sub ["ATL_DB_ROOT_PASSWORD=${DBMasterUserPassword}", DBMasterUserPassword: !Ref DBMasterUserPassword]
                   - !Sub ["ATL_DB_HOST=${DBEndpointAddress}", DBEndpointAddress: !GetAtt DB.Endpoint.Address]
                   - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !GetAtt DB.Endpoint.Port]
-                  - ATL_JDBC_DRIVER=org.postgresql.Driver
-                  - !Sub
-                    - "ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/bitbucket"
-                    - DBEndpointAddress: !GetAtt DB.Endpoint.Address
-                      DBEndpointPort: !GetAtt DB.Endpoint.Port
-                  - ATL_JDBC_USER=atlbitbucket
-                  - !Sub ["ATL_JDBC_PASSWORD=${DBPassword}", DBPassword: !Ref DBPassword]
-                  - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}", BitbucketProperties: !Join ["\n", !Ref BitbucketProperties]]
-                  - hazelcast.network.aws=true
-                  - !Sub ["hazelcast.network.aws.iam.role=${BitbucketClusterNodeRole}", BitbucketClusterNodeRole: !Ref BitbucketClusterNodeRole]
-                  - !Sub ["hazelcast.network.aws.region=${Region}", Region: !Ref "AWS::Region"]
-                  - hazelcast.network.aws.tag.key=Cluster
-                  - !Sub ["hazelcast.network.aws.tag.value=${StackName}", StackName: !Ref "AWS::StackName"]
-                  - hazelcast.network.multicast=false
-                  - !Sub ["hazelcast.group.name=${StackName}", StackName: !Ref "AWS::StackName"]
-                  - !Sub ["hazelcast.group.password=${StackName}", StackName: !Ref "AWS::StackName"]
-                  - !Sub ["plugin.search.elasticsearch.aws.region=${Region}", Region: !Ref "AWS::Region"]
-                  - !Sub ["plugin.search.elasticsearch.baseurl=https://${ESEndpoint}\"", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
-                  - !Sub ["ATL_BITBUCKET_VERSION=${BitbucketVersion}", BitbucketVersion: !Ref BitbucketVersion]
-                  - ATL_BITBUCKET_BUNDLED_ELASTICSEARCH_ENABLED=false
-                  - ATL_NGINX_ENABLED=false
-                  - ATL_POSTGRES_ENABLED=false
-                  - !Sub ["ATL_PROXY_NAME=${LoadBalancerDNSName}", LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName]
-                  - ATL_SSL_SELF_CERT_ENABLED=false
-                  - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]
-                  - !Join ["\n", !Ref AMIOpts]
-            /etc/cfn/cfn-hup.conf:
-              content: !Join
-                - "\n"
-                -
-                  - "[main]"
-                  - !Sub ["stack=${StackId}", StackId: !Ref "AWS::StackId"]
-                  - !Sub ["region=${Region}", Region: !Ref "AWS::Region"]
-              mode: '000400'
+                  - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/confluence", { DBEndpointAddress: !GetAtt DB.Endpoint.Address, DBEndpointPort: !GetAtt DB.Endpoint.Port }]
+                  - ""
+                  - !Sub ["ATL_RDS_INSTANCE_ID=${DB}", DB: !Ref "DB"]
+                  - !Sub ["ATL_RDS_INSTANCE_CLASS=${DBInstanceClass}", DBInstanceClass: !Ref "DBInstanceClass"]
+                  - !Sub ["ATL_RDS_MULTI_AZ=${DBMultiAZ}", DBMultiAZ: !Ref "DBMultiAZ"]
+                  - !Sub ["ATL_RDS_SUBNET_GROUP_NAME=${DBSubnetGroup}", DBSubnetGroup: !Ref "DBSubnetGroup"]
+                  - !Sub ["ATL_RDS_SECURITY_GROUP=${SecurityGroup}", SecurityGroup: !Ref "SecurityGroup"]
+                  - ""
+                  - !Sub ["ATL_NFS_DISK_VOLUME_TYPE=${VolType}", VolType: !If [IsHomeProvisionedIops, "io1", "gp2"]]
+                  - !Sub ["ATL_NFS_DISK_VOLUME_IOPS=${VolIOPs}", VolIOPs: !If [IsHomeProvisionedIops, !Ref "HomeIops", ""]]
+                  - ""
+                  - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
+                  - !Sub ["ATL_ELASTICSEARCH_ENDPOINT=http://${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
+                  - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Join ["\\\n", !Ref BitbucketProperties]]
+                  - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]                  
+
+            /opt/atlassian/bin/clone_deployment_repo:
+              content: !Sub |
+                #!/bin/bash
+                key_location=/root/.ssh/deployment_repo_key
+                key_name="${DeploymentAutomationKeyName}"
+
+                yum install -y git
+                if [[ ! -z "$key_name" ]]; then
+                    # Ensure awscli is up to date
+                    yum install -y awscli jq
+                    key_val=$(aws --region=${AWS::Region} ssm get-parameters --names "$key_name" --with-decryption | jq --raw-output '.Parameters[0] .Value')
+                    echo -e $key_val > $key_location
+                    chmod 600 $key_location
+                    export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i $key_location"
+                else
+                    export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
+                fi
+
+                git clone "${DeploymentAutomationRepository}" -b "${DeploymentAutomationBranch}" /opt/atlassian/dc-deployments-automation/
+              mode: "000750"
               owner: root
               group: root
-            /etc/cfn/hooks.d/cfn-auto-reloader.conf:
-              content:
-                !Join
-                - "\n"
-                -
-                  - "[cfn-auto-reloader-hook]"
-                  - triggers=post.update
-                  - "path=Resources.ClusterNodeLaunchConfig.Metadata.AWS::CloudFormation::Init"
-                  - !Sub
-                    - "action=/opt/aws/bin/cfn-init -v --stack ${StackName} --resource ClusterNodeLaunchConfig --region ${Region}"
-                    - StackName: !Ref "AWS::StackName"
-                      Region: !Ref "AWS::Region"
-                  - runas=root
-            /home/atlbitbucket/.bash_profile:
-              content:
-                !Join
-                - "\n"
-                -
-                  - if [ -f ~/.bashrc ]; then
-                  -     . ~/.bashrc
-                  - fi
-                  - !Sub ["export CATALINA_OPTS=\"${CatalinaOpts}\"", CatalinaOpts: !Ref CatalinaOpts]
-              mode: '000644'
-              owner: atlbitbucket
-              group: atlbitbucket
+
           commands:
-            010_add_nfs_mount:
-              command: !Sub
-                - "echo ${FileServerPrivateIp}:/media/atl/bitbucket/shared /media/atl/bitbucket/shared nfs lookupcache=pos,noatime,intr,rsize=32768,wsize=32768 0 0 >>/etc/fstab"
-                - FileServerPrivateIp: !GetAtt FileServer.PrivateIp
+            070_create_atl_dir:
+              test: "test ! -d /opt/atlassian/"
+              command: mkdir -p /opt/atlassian
               ignoreErrors: false
-            020_make_shared_home_dir:
-              command: mkdir -p /media/atl/bitbucket/shared
-              ignoreErrors: false
-            030_chown_shared_home_dir:
-              command: "chown atlbitbucket:atlbitbucket /media/atl/bitbucket /media/atl/bitbucket/shared"
-              ignoreErrors: false
-          services:
-            sysvinit:
-              cfn-hup:
-                enabled: true
-                ensureRunning: true
-                files: [/etc/cfn/cfn-hup.conf, /etc/cfn/hooks.d/cfn-auto-reloader.conf]
-              collectd:
-                !If [SetupCollectd, {enabled: true, ensureRunning: true}, !Ref "AWS::NoValue"]
-              rpcbind:
-                enabled: true
-                ensureRunning: true
-                packages:
-                  yum: [nfs-utils]
-        '2':
-          commands:
-            040_mount_nfs:
-              command: "bash -c \"until mount /media/atl/bitbucket/shared; do echo 'Mount of shared volume failed trying again in 5 seconds.'; sleep 5; done\""
-              ignoreErrors: false
-          services:
-            sysvinit:
-              nfslock:
-                enabled: true
-                ensureRunning: true
-                packages:
-                  yum: [nfs-utils]
+            071_install_packages:
+              command: yum install -y git python-virtualenv
+              ignoreErrors: true
+            072_clone_atl_scripts:
+              test: "test ! -d /opt/atlassian/dc-deployments-automation/"
+              command: /opt/atlassian/bin/clone_deployment_repo
+              ignoreErrors: true
+            080_run_atl_init_node:
+              command: !Sub |
+                cd /opt/atlassian/dc-deployments-automation/ && ./bin/install-ansible && ./bin/ansible-with-atl-env inv/aws_node_local ${DeploymentAutomationPlaybook} /var/log/ansible-bootstrap.log
+              ignoreErrors: true
+
     Properties:
       AssociatePublicIpAddress: false
       BlockDeviceMappings:
-        - DeviceName: /dev/xvdf
+        - DeviceName: /dev/sdf
           Ebs: {}
           NoDevice: true
       KeyName: !If [ KeyProvided, !Ref KeyPairName, !ImportValue ATL-DefaultKey ]
@@ -855,17 +864,7 @@ Resources:
     Metadata:
       Comment: Set up NFS Server and initial bitbucket.properties
       AWS::CloudFormation::Init:
-        "1":
-          packages:
-            !If
-            - SetupCollectd
-            -
-              yum:
-                collectd: []
-                collectd-java: []
-                collectd-generic-jmx: []
-                collectd-rrdtool: []
-            - !Ref "AWS::NoValue"
+        config:
           files:
             /etc/atl:
               content:
@@ -874,143 +873,85 @@ Resources:
                 -
                   - ATL_ENABLED_PRODUCTS=
                   - ATL_ENABLED_SHARED_HOMES=Bitbucket
-                  - ATL_NGINX_ENABLED=false
-                  - ATL_POSTGRES_ENABLED=false
-                  - ATL_SSL_SELF_CERT_ENABLED=false
-                  - ATL_BITBUCKET_BUNDLED_ELASTICSEARCH_ENABLED=false
                   - ATL_APP_NFS_SERVER=true
-            /etc/cfn/cfn-hup.conf:
-              content:
-                !Join
-                - "\n"
-                -
-                  - "[main]"
-                  - !Sub ["stack=${StackId}", StackId: !Ref "AWS::StackId"]
-                  - !Sub ["region=${Region}", Region: !Ref "AWS::Region"]
-              mode: "000400"
+                  - ATL_NFS_SERVER_DEVICE=/dev/sdf
+                  # NOTE: For simplicity we should keep this as close to the BB node version above.
+                  - !Sub ["ATL_PRODUCT_VERSION=${BitbucketVersion}", BitbucketVersion: !Ref BitbucketVersion]
+                  - !Sub ["ATL_PROXY_NAME=${LoadBalancerDNSName}", LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName]
+                  - ""
+                  - !Sub ["ATL_AWS_REGION=${Region}", Region: !Ref "AWS::Region"]
+                  - !Sub ["ATL_AWS_STACK_NAME=${StackName}", StackName: !Ref "AWS::StackName"]
+                  - !Sub ["ATL_AWS_IAM_ROLE=${Role}", Role: !Ref BitbucketFileServerRole]
+                  - !Sub ["ATL_AWS_IAM_ROLE_ARN=${Role}", Role: !GetAtt BitbucketFileServerRole.Arn]
+                  - ""
+                  - "ATL_JDBC_DB_NAME=bitbucket"
+                  - "ATL_JDBC_DRIVER=org.postgresql.Driver"
+                  - "ATL_JDBC_USER=atlbitbucket"
+                  - !Sub ["ATL_JDBC_PASSWORD=${DBPassword}", DBPassword: !Ref DBPassword]
+                  - !Sub ["ATL_DB_ROOT_PASSWORD=${DBMasterUserPassword}", DBMasterUserPassword: !Ref DBMasterUserPassword]
+                  - !Sub ["ATL_DB_HOST=${DBEndpointAddress}", DBEndpointAddress: !GetAtt DB.Endpoint.Address]
+                  - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !GetAtt DB.Endpoint.Port]
+                  - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/confluence", { DBEndpointAddress: !GetAtt DB.Endpoint.Address, DBEndpointPort: !GetAtt DB.Endpoint.Port }]
+                  - ""
+                  - !Sub ["ATL_RDS_INSTANCE_ID=${DB}", DB: !Ref "DB"]
+                  - !Sub ["ATL_RDS_INSTANCE_CLASS=${DBInstanceClass}", DBInstanceClass: !Ref "DBInstanceClass"]
+                  - !Sub ["ATL_RDS_MULTI_AZ=${DBMultiAZ}", DBMultiAZ: !Ref "DBMultiAZ"]
+                  - !Sub ["ATL_RDS_SUBNET_GROUP_NAME=${DBSubnetGroup}", DBSubnetGroup: !Ref "DBSubnetGroup"]
+                  - !Sub ["ATL_RDS_SECURITY_GROUP=${SecurityGroup}", SecurityGroup: !Ref "SecurityGroup"]
+                  - ""
+                  - !Sub ["ATL_NFS_DISK_VOLUME_TYPE=${VolType}", VolType: !If [IsHomeProvisionedIops, "io1", "gp2"]]
+                  - !Sub ["ATL_NFS_DISK_VOLUME_IOPS=${VolIOPs}", VolIOPs: !If [IsHomeProvisionedIops, !Ref "HomeIops", ""]]
+                  - ""
+                  - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
+                  - !Sub ["ATL_ELASTICSEARCH_S3_BUCKET=${BucketName}", BucketName: !Ref ESBucketName]
+                  - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Join ["\\\n", !Ref BitbucketProperties]]
+                  - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]
+                  - ""
+                  - !Sub ["ATL_DEPLOYMENT_REPOSITORY=${DeployRepository}", DeployRepository: !Ref "DeploymentAutomationRepository"]
+                  - !Sub ["ATL_DEPLOYMENT_REPOSITORY_BRANCH=${DeployRepositoryBranch}", DeployRepositoryBranch: !Ref "DeploymentAutomationBranch"]
+                  - !Sub ["ATL_DEPLOYMENT_REPOSITORY_PLAYBOOK=${DeployRepositoryPlaybook}", DeployRepositoryPlaybook: !Ref "DeploymentAutomationPlaybook"]
+                  - !Sub ["ATL_DEPLOYMENT_REPOSITORY_KEYNAME=${DeployRepositoryKeyName}", DeployRepositoryKeyName: !Ref "DeploymentAutomationKeyName"]
+
+            /opt/atlassian/bin/clone_deployment_repo:
+              content: !Sub |
+                #!/bin/bash
+                key_location=/root/.ssh/deployment_repo_key
+                key_name="${DeploymentAutomationKeyName}"
+
+                yum install -y git
+                if [[ ! -z "$key_name" ]]; then
+                    # Ensure awscli is up to date
+                    yum install -y awscli jq
+                    key_val=$(aws --region=${AWS::Region} ssm get-parameters --names "$key_name" --with-decryption | jq --raw-output '.Parameters[0] .Value')
+                    echo -e $key_val > $key_location
+                    chmod 600 $key_location
+                    export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -i $key_location"
+                else
+                    export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
+                fi
+
+                git clone "${DeploymentAutomationRepository}" -b "${DeploymentAutomationBranch}" /opt/atlassian/dc-deployments-automation/
+              mode: "000750"
               owner: root
               group: root
-            /etc/cfn/hooks.d/cfn-auto-reloader.conf:
-              content:
-                !Join
-                - "\n"
-                -
-                  - "[cfn-auto-reloader-hook]"
-                  - triggers=post.update
-                  - "path=Resources.FileServer.Metadata.AWS::CloudFormation::Init"
-                  - !Sub
-                    - "action=/opt/aws/bin/cfn-init -v --stack ${StackName} --resource FileServer --region ${Region}"
-                    - Region: !Ref "AWS::Region"
-                      StackName: !Ref "AWS::StackName"
-                  - runas=root
-            /opt/atlassian/bitbucket-diy-backup/bitbucket.diy-backup.vars.sh:
-              content:
-                !Join
-                - "\n"
-                -
-                  - "# This file was generated from the BitbucketDataCenter CloudFormation template"
-                  - !Sub ["INSTANCE_NAME=${StackName}", StackName: !Ref "AWS::StackName"]
-                  - !Sub
-                    - "BITBUCKET_URL=${HTTP}://${LoadBalancerDNSName}"
-                    - HTTP: !If [DoSSL, "https", "http"]
-                      LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName
-                  - BITBUCKET_HOME=/media/atl/bitbucket
-                  - BITBUCKET_UID=atlbitbucket
-                  - BITBUCKET_GID=atlbitbucket
-                  - !If
-                    - StandbyMode
-                    - "BACKUP_DISK_TYPE=${BACKUP_DISK_TYPE:-zfs}"
-                    - "BACKUP_DISK_TYPE=${BACKUP_DISK_TYPE:-amazon-ebs}"
-                  - "BACKUP_DATABASE_TYPE=${BACKUP_DATABASE_TYPE:-amazon-rds}"
-                  - BACKUP_ARCHIVE_TYPE=
-                  - "BACKUP_ELASTICSEARCH_TYPE=amazon-es"
-                  - "BACKUP_ZERO_DOWNTIME=true"
-                  - HOME_DIRECTORY_MOUNT_POINT=/media/atl
-                  - "EBS_VOLUME_MOUNT_POINT_AND_DEVICE_NAMES=(/media/atl:/dev/sdf)"
-                  - !Sub ["RESTORE_DISK_VOLUME_TYPE=${HomeProvisionedIops}", HomeProvisionedIops: !If [IsHomeProvisionedIops, "io1", "gp2"]]
-                  - !If [IsHomeProvisionedIops, !Sub ["RESTORE_DISK_IOPS=${HomeIops}", HomeIops: !Ref "HomeIops"], !Ref "AWS::NoValue"]
-                  - FILESYSTEM_TYPE=zfs
-                  - "ZFS_FILESYSTEM_NAMES=()"
-                  - "for volume in \"${EBS_VOLUME_MOUNT_POINT_AND_DEVICE_NAMES[@]}\"; do"
-                  - "    mount_point=\"$(echo \"${volume}\" | cut -d \":\" -f1)\""
-                  - "    ZFS_FILESYSTEM_NAMES+=($(run sudo zfs list -H -o name,mountpoint | grep \"${mount_point}\" | cut -f1))"
-                  - "done"
-                  - !Sub ["RDS_INSTANCE_ID=${DB}", DB: !Ref "DB"]
-                  - !Sub ["RESTORE_RDS_INSTANCE_CLASS=${DBInstanceClass}", DBInstanceClass: !Ref "DBInstanceClass"]
-                  - !Sub ["RESTORE_RDS_MULTI_AZ=${DBMultiAZ}", DBMultiAZ: !Ref "DBMultiAZ"]
-                  - !Sub ["RESTORE_RDS_SUBNET_GROUP_NAME=${DBSubnetGroup}", DBSubnetGroup: !Ref "DBSubnetGroup"]
-                  - !Sub ["RESTORE_RDS_SECURITY_GROUP=${SecurityGroup}", SecurityGroup: !Ref "SecurityGroup"]
-                  - "CURL_OPTIONS=\"-L -s -f\""
-                  - !Sub ["AWS_REGION=${Region}", Region: !Ref "AWS::Region"]
-                  - "AWS_INFO=$(curl ${CURL_OPTIONS} http://169.254.169.254/latest/dynamic/instance-identity/document)"
-                  - "AWS_ACCOUNT_ID=$(echo \"${AWS_INFO}\" | jq -r .accountId)"
-                  - "AWS_AVAILABILITY_ZONE=$(echo \"${AWS_INFO}\" | jq -r .availabilityZone)"
-                  - "AWS_REGION=$(echo \"${AWS_INFO}\" | jq -r .region)"
-                  - "AWS_EC2_INSTANCE_ID=$(echo \"${AWS_INFO}\" | jq -r .instanceId)"
-                  - AWS_ADDITIONAL_TAGS=
-                  - "BITBUCKET_VERBOSE_BACKUP=${BITBUCKET_VERBOSE_BACKUP:-true}"
-                  - KEEP_BACKUPS=5
-                  - "ELASTICSEARCH_REPOSITORY_NAME=bitbucket-snapshots"
-                  - "ELASTICSEARCH_INDEX_NAME=bitbucket-search-v1"
-                  - !Sub ["ELASTICSEARCH_S3_BUCKET=${BucketName}", BucketName: !Ref ESBucketName]
-                  - !Sub ["ELASTICSEARCH_S3_BUCKET_REGION=${Region}", Region: !Ref "AWS::Region"]
-                  - !Sub ["ELASTICSEARCH_SNAPSHOT_IAM_ROLE=${Role}", Role: !GetAtt BitbucketFileServerRole.Arn]
-                  - !Sub ["ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
-                  - !If
-                    - StandbyMode
-                    - !Sub ["STANDBY_JDBC_URL=jdbc:postgres://${DBEndpointAddress}/bitbucket", DBEndpointAddress: !GetAtt DB.Endpoint.Address]
-                    - !Ref "AWS::NoValue"
-                  - !If
-                    - StandbyMode
-                    - !Sub ["DR_RDS_READ_REPLICA=${DB}", DB: !Ref DB]
-                    - !Ref "AWS::NoValue"
-              mode: "000644"
-              owner: "ec2-user"
-              group: "ec2-user"
+
           commands:
-            010_pull_diy_backup_repo:
-              command: "git pull"
-              cwd: "/opt/atlassian/bitbucket-diy-backup"
+            070_create_atl_dir:
+              test: "test ! -d /opt/atlassian/"
+              command: mkdir -p /opt/atlassian
+              ignoreErrors: false
+            071_install_packages:
+              command: yum install -y git python-virtualenv
               ignoreErrors: true
-          services:
-            sysvinit:
-              cfn-hup:
-                enabled: true
-                ensureRunning: true
-                files: [/etc/cfn/cfn-hup.conf, /etc/cfn/hooks.d/cfn-auto-reloader.conf]
-              collectd:
-                !If
-                - SetupCollectd
-                - enabled: true
-                  ensureRunning: true
-                - !Ref "AWS::NoValue"
-              rpcbind:
-                enabled: true
-                ensureRunning: true
-        "2":
-          services:
-            sysvinit:
-              nfs:
-                enabled: true
-                ensureRunning: true
-              nfslock:
-                enabled: true
-                ensureRunning: true
-          commands:
-            !If
-            - RestoreFromESSnapshot
-            - 020_restore_es_snapshot:
-                command: !Sub
-                  - "/opt/atlassian/bitbucket-diy-backup/bitbucket.diy-restore.sh ${ESSnapshotId}"
-                  - ESSnapshotId: !Ref "ESSnapshotId"
-                ignoreErrors: false
-                env:
-                  SNAPSHOT_TAG_PREFIX: !Ref "ESSnapshotId"
-                  BACKUP_DISK_TYPE: "none"
-                  BACKUP_DATABASE_TYPE: "none"
-            - !Ref "AWS::NoValue"
-        configSets:
-          default: [1, 2]
+            072_clone_atl_scripts:
+              test: "test ! -d /opt/atlassian/dc-deployments-automation/"
+              command: /opt/atlassian/bin/clone_deployment_repo
+              ignoreErrors: true
+            080_run_atl_init_node:
+              command: !Sub |
+                cd /opt/atlassian/dc-deployments-automation/ && ./bin/install-ansible && ./bin/ansible-with-atl-env inv/aws_node_local aws_bitbucket_nfs_node.yml /var/log/ansible-bootstrap.log
+              ignoreErrors: true
+
     Properties:
       BlockDeviceMappings:
         - DeviceName: /dev/sdf
@@ -1020,7 +961,7 @@ Resources:
             DeleteOnTermination: !Ref HomeDeleteOnTermination
             SnapshotId: !If [RestoreFromEBSSnapshot, !Ref HomeVolumeSnapshotId, !Ref "AWS::NoValue"]
             VolumeSize: !Ref HomeSize
-        - DeviceName: /dev/xvdf
+        - DeviceName: /dev/sdf
           NoDevice: {}
       IamInstanceProfile: !Ref BitbucketFileServerInstanceProfile
       EbsOptimized: true

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -705,8 +705,8 @@ Resources:
                   - "ATL_JDBC_DB_NAME=bitbucket"
                   - "ATL_JDBC_DRIVER=org.postgresql.Driver"
                   - "ATL_JDBC_USER=atlbitbucket"
-                  - !Sub ["ATL_JDBC_PASSWORD=${DBPassword}", DBPassword: !Ref DBPassword]
-                  - !Sub ["ATL_DB_ROOT_PASSWORD=${DBMasterUserPassword}", DBMasterUserPassword: !Ref DBMasterUserPassword]
+                  - !Sub ["ATL_JDBC_PASSWORD='${DBPassword}'", DBPassword: !Ref DBPassword]
+                  - !Sub ["ATL_DB_ROOT_PASSWORD='${DBMasterUserPassword}'", DBMasterUserPassword: !Ref DBMasterUserPassword]
                   - !Sub ["ATL_DB_HOST=${DBEndpointAddress}", DBEndpointAddress: !GetAtt DB.Endpoint.Address]
                   - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !GetAtt DB.Endpoint.Port]
                   - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/confluence", { DBEndpointAddress: !GetAtt DB.Endpoint.Address, DBEndpointPort: !GetAtt DB.Endpoint.Port }]
@@ -890,8 +890,8 @@ Resources:
                   - "ATL_JDBC_DB_NAME=bitbucket"
                   - "ATL_JDBC_DRIVER=org.postgresql.Driver"
                   - "ATL_JDBC_USER=atlbitbucket"
-                  - !Sub ["ATL_JDBC_PASSWORD=${DBPassword}", DBPassword: !Ref DBPassword]
-                  - !Sub ["ATL_DB_ROOT_PASSWORD=${DBMasterUserPassword}", DBMasterUserPassword: !Ref DBMasterUserPassword]
+                  - !Sub ["ATL_JDBC_PASSWORD='${DBPassword}'", DBPassword: !Ref DBPassword]
+                  - !Sub ["ATL_DB_ROOT_PASSWORD='${DBMasterUserPassword}'", DBMasterUserPassword: !Ref DBMasterUserPassword]
                   - !Sub ["ATL_DB_HOST=${DBEndpointAddress}", DBEndpointAddress: !GetAtt DB.Endpoint.Address]
                   - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !GetAtt DB.Endpoint.Port]
                   - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/confluence", { DBEndpointAddress: !GetAtt DB.Endpoint.Address, DBEndpointPort: !GetAtt DB.Endpoint.Port }]
@@ -963,6 +963,7 @@ Resources:
             Iops: !If [IsHomeProvisionedIops, !Ref HomeIops, !Ref "AWS::NoValue"]
             SnapshotId: !If [RestoreFromEBSSnapshot, !Ref HomeVolumeSnapshotId, !Ref "AWS::NoValue"]
             VolumeSize: !Ref HomeSize
+            VolumeType: !If [IsHomeProvisionedIops, io1, gp2]
       IamInstanceProfile: !Ref BitbucketFileServerInstanceProfile
       EbsOptimized: true
       ImageId:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -41,12 +41,14 @@ Metadata:
           - AssociatePublicIpAddress
           - CidrBlock
           - KeyPairName
+          - CustomDnsName
           - SSLCertificateARN
       - Label:
           default: Advanced (Optional)
         Parameters:
           - BitbucketProperties
-          - CatalinaOpts
+          - JvmHeapOverride
+          - JvmSupportOpts
           - CreateBucket
           - DBMaster
           - DBSnapshotId
@@ -66,8 +68,10 @@ Metadata:
         default: Bitbucket properties
       BitbucketVersion:
         default: Version *
-      CatalinaOpts:
-        default: Catalina options
+      JvmHeapOverride:
+        default: JVM Heap Size Override
+      JvmSupportOpts:
+        default: Additional JVM options
       CidrBlock:
         default: Permitted IP range *
       ClusterNodeMax:
@@ -124,6 +128,8 @@ Metadata:
         default: Home directory volume type
       KeyPairName:
         default: Key Name *
+      CustomDnsName:
+        default: Existing DNS name (optional)
       SSLCertificateARN:
         default: SSL Certificate ARN
 
@@ -144,9 +150,13 @@ Parameters:
     ConstraintDescription: 'Must be a valid Bitbucket version number. For example: 5.0.0 or higher'
     Description: 'Version of Bitbucket to install. Please use version 5.0.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases'
     Type: String
-  CatalinaOpts:
+  JvmHeapOverride:
     Default: ''
-    Description: Pass in any additional JVM options to tune Catalina Tomcat
+    Description: Override the default amount of memory to allocate to the JVM for your instance type - set size in meg or gig e.g. 1024m or 1g
+    Type: String
+  JvmSupportOpts:
+    Default: ''
+    Description: Pass in any additional JVM options to tune the Bitbucket instance
     Type: String
   CidrBlock:
     AllowedPattern: '(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})'
@@ -452,6 +462,10 @@ Parameters:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances
     Type: AWS::EC2::KeyPair::KeyName
+  CustomDnsName:
+    Default: ""
+    Description: 'Use custom existing DNS name for your Data Center instance. Please note: you must own the domain and configure it to point at the load balancer.'
+    Type: String
   SSLCertificateARN:
     Default: ''
     Description: Amazon Resource Name (ARN) of your SSL certificate. If you want to use your own certificate that you generated outside of Amazon, you need to first import it to AWS Certificate Manager. After a successful import, you'll receive the ARN. If you want to create a certificate with AWS Certificate Manager (ACM certificate), you will receive the ARN after it's successfully created.
@@ -480,6 +494,8 @@ Conditions:
     !Not [!Equals [!Ref ESBucketName, '']]
   StandbyMode:
     !Not [!Equals [!Ref DBMaster, '']]
+  UseCustomDnsName:
+    !Not [!Equals [!Ref CustomDnsName, '']]
   DoSSL:
     !Not [!Equals [!Ref SSLCertificateARN, '']]
   NotStandbyMode:
@@ -683,12 +699,15 @@ Resources:
                   - "ATL_APP_DATA_MOUNT_ENABLED=false"
                   - ""
                   - !Sub ["ATL_PRODUCT_VERSION=${BitbucketVersion}", BitbucketVersion: !Ref BitbucketVersion]
-                  - !Sub ["ATL_PROXY_NAME=${LoadBalancerDNSName}", LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName]
+                  - !Sub ["ATL_PROXY_NAME=${AtlProxyName}", AtlProxyName: !If [UseCustomDnsName, !Ref CustomDnsName, !GetAtt LoadBalancer.DNSName]]
                   - !Sub ["ATL_FILESERVER_IP=${FileServerPrivateIp}", FileServerPrivateIp: !GetAtt FileServer.PrivateIp]
                   - !Sub ["ATL_DEPLOYMENT_REPOSITORY=${DeployRepository}", DeployRepository: !Ref "DeploymentAutomationRepository"]
                   - !Sub ["ATL_DEPLOYMENT_REPOSITORY_BRANCH=${DeployRepositoryBranch}", DeployRepositoryBranch: !Ref "DeploymentAutomationBranch"]
                   - !Sub ["ATL_DEPLOYMENT_REPOSITORY_PLAYBOOK=${DeployRepositoryPlaybook}", DeployRepositoryPlaybook: !Ref "DeploymentAutomationPlaybook"]
                   - !Sub ["ATL_DEPLOYMENT_REPOSITORY_KEYNAME=${DeployRepositoryKeyName}", DeployRepositoryKeyName: !Ref "DeploymentAutomationKeyName"]
+                  - ""
+                  - !Sub ["ATL_JVM_HEAP=${JvmHeapOverride}", JvmHeapOverride: !Ref "JvmHeapOverride"]
+                  - !Sub ["ATL_JVM_OPTS=${JvmSupportOpts}", JvmSupportOpts: !Ref "JvmSupportOpts"]
                   - ""
                   - !Sub ["ATL_AWS_REGION=${Region}", Region: !Ref "AWS::Region"]
                   - !Sub ["ATL_AWS_STACK_NAME=${StackName}", StackName: !Ref "AWS::StackName"]
@@ -1111,11 +1130,17 @@ Outputs:
     Description: The RDS ARN to use when creating a Data Center standby stack
     Value: !If [NotStandbyMode, !Sub ["arn:aws:rds:${AWS::Region}:${AWS::AccountId}:db:${DB}", {DB: !Ref "DB"}], !Ref "AWS::NoValue"]
   ServiceURL:
-    Description: The URL of the Bitbucket Data Center instance
-    Value: !Sub
-      - "${HTTP}://${LoadBalancerDNSName}"
-      - HTTP: !If [DoSSL, https, http]
-        LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName
+    Description: The URL to access this Atlassian service
+    Value: !If
+      - UseCustomDnsName
+      - !Sub
+        - "${HTTP}://${CustomDNSName}"
+        - HTTP: !If [DoSSL, https, http]
+          CustomDNSName: !Ref CustomDnsName
+      - !Sub
+        - "${HTTP}://${LoadBalancerDNSName}"
+        - HTTP: !If [DoSSL, https, http]
+          LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName
   SGname:
     Description: The name of the SecurityGroup
     Value: !Ref SecurityGroup

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -38,8 +38,8 @@ Metadata:
       - Label:
           default: Networking
         Parameters:
-          - AssociatePublicIpAddress
           - CidrBlock
+          - InternetFacingLoadBalancer
           - KeyPairName
           - CustomDnsName
           - SSLCertificateARN
@@ -62,8 +62,6 @@ Metadata:
           - DeploymentAutomationKeyName
 
     ParameterLabels:
-      AssociatePublicIpAddress:
-        default: Assign public IP
       BitbucketProperties:
         default: Bitbucket properties
       BitbucketVersion:
@@ -126,6 +124,8 @@ Metadata:
         default: Home volume snapshot ID to restore
       HomeVolumeType:
         default: Home directory volume type
+      InternetFacingLoadBalancer:
+        default: Make instance internet facing
       KeyPairName:
         default: Key Name *
       CustomDnsName:
@@ -134,12 +134,6 @@ Metadata:
         default: SSL Certificate ARN
 
 Parameters:
-  AssociatePublicIpAddress:
-    Default: true
-    AllowedValues: [true, false]
-    ConstraintDescription: Must be 'true' or 'false'.
-    Description: Controls if the EC2 instances are assigned a public IP address
-    Type: String
   BitbucketProperties:
     Default: ''
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
@@ -446,6 +440,12 @@ Parameters:
     AllowedValues: [General Purpose (SSD), Provisioned IOPS]
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Type: String
+  InternetFacingLoadBalancer:
+    Default: true
+    AllowedValues: [true, false]
+    ConstraintDescription: Must be 'true' or 'false'.
+    Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
+    Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances
@@ -515,7 +515,7 @@ Conditions:
   SetDBMasterUserPassword:
     !And [!Not [!Equals [!Ref DBMasterUserPassword, '']], Condition: NotStandbyMode]
   UsePublicIp:
-    !Equals [!Ref AssociatePublicIpAddress, 'true']
+    !Equals [!Ref InternetFacingLoadBalancer, 'true']
 
 Mappings:
   AWSRegionArch2AMI:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -319,12 +319,12 @@ Parameters:
     MaxValue: 30000
     Type: Number
   DBMasterUserPassword:
-    AllowedPattern: '[a-zA-Z0-9]*'
-    ConstraintDescription: Must be at least 8 alphanumeric characters.
-    Description: Password for the master ('postgres') account.
-    MinLength: 8
+    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
+    ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    Description: Password for the master ('postgres') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    NoEcho: True
     MaxLength: 128
-    NoEcho: true
+    MinLength: 8
     Type: String
   DBMultiAZ:
     Description: Whether to provision a multi-AZ RDS instance.
@@ -335,9 +335,9 @@ Parameters:
     ConstraintDescription: Must be 'true' or 'false'.
     Type: String
   DBPassword:
-    AllowedPattern: '[a-zA-Z0-9]*'
-    ConstraintDescription: If specified, must be at least 8 alphanumeric characters.
-    Description: Password for the Bitbucket user ('atlbitbucket') account. Max length of 128 characters. Not used if you have specified a Database snapshot ID.
+    AllowedPattern: '(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*'
+    ConstraintDescription: Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
+    Description: Password for the Bitbucket user ('atlbitbucket') account. Must be at least 8 characters and include 1 uppercase, 1 lowercase, 1 number, 1 (non / @ " ') symbol
     MaxLength: 128
     NoEcho: true
     Type: String
@@ -512,7 +512,7 @@ Conditions:
     !And [Condition: IsVersion5X, !Or [Condition: IsVersionX0, Condition: IsVersionX1, Condition: IsVersionX2, Condition: IsVersionX3, Condition: IsVersionX4, Condition: IsVersionX5, Condition: IsVersionX6]]
   RestoreRDSOrStandby:
     !Or [Condition: RestoreFromRDSSnapshot, Condition: StandbyMode]
-  SetDBMasterUserPassword:
+  SetDBMasterUserAndPassword:
     !And [!Not [!Equals [!Ref DBMasterUserPassword, '']], Condition: NotStandbyMode]
   UsePublicIp:
     !Equals [!Ref InternetFacingLoadBalancer, 'true']
@@ -659,9 +659,9 @@ Resources:
   ClusterNodeGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      DesiredCapacity: !If [StandbyMode, 0, !Ref ClusterNodeMin]
+      DesiredCapacity: !If [StandbyMode, '0', !Ref ClusterNodeMin]
       LaunchConfigurationName: !Ref ClusterNodeLaunchConfig
-      MinSize: !If [StandbyMode, 0, !Ref ClusterNodeMin]
+      MinSize: !If [StandbyMode, '0', !Ref ClusterNodeMin]
       MaxSize: !Ref ClusterNodeMax
       LoadBalancerNames: [!Ref LoadBalancer]
       VPCZoneIdentifier: !Select [0, [!Split [ ',', !ImportValue ATL-PriNets]]]
@@ -723,7 +723,7 @@ Resources:
                   - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
                   - !Sub ["ATL_ELASTICSEARCH_ENDPOINT=http://${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
                   - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Join ["\\\n", !Ref BitbucketProperties]]
-                  - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]                  
+                  - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]
 
             /opt/atlassian/bin/clone_deployment_repo:
               content: !Sub |
@@ -769,7 +769,6 @@ Resources:
       AssociatePublicIpAddress: false
       BlockDeviceMappings:
         - DeviceName: /dev/sdf
-          Ebs: {}
           NoDevice: true
       KeyName: !If [ KeyProvided, !Ref KeyPairName, !ImportValue ATL-DefaultKey ]
       IamInstanceProfile: !Ref BitbucketClusterNodeInstanceProfile
@@ -796,14 +795,14 @@ Resources:
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: !Ref ClusterNodeGroup
-      Cooldown: 600
+      Cooldown: '600'
       ScalingAdjustment: 1
   ClusterNodeScaleDownPolicy:
     Type: AWS::AutoScaling::ScalingPolicy
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: !Ref ClusterNodeGroup
-      Cooldown: 600
+      Cooldown: '600'
       ScalingAdjustment: -1
   CPUAlarmHigh:
     Type: AWS::CloudWatch::Alarm
@@ -955,7 +954,7 @@ Resources:
               command: /opt/atlassian/bin/clone_deployment_repo
               ignoreErrors: true
             080_run_atl_init_node:
-              command: !Sub |
+              command:
                 cd /opt/atlassian/dc-deployments-automation/ && ./bin/install-ansible && ./bin/ansible-with-atl-env inv/aws_node_local aws_bitbucket_nfs_node.yml /var/log/ansible-bootstrap.log
               ignoreErrors: true
 
@@ -963,11 +962,11 @@ Resources:
       BlockDeviceMappings:
         - DeviceName: /dev/sdf
           Ebs:
-            VolumeType: !If [IsHomeProvisionedIops, io1, gp2]
-            Iops: !If [IsHomeProvisionedIops, !Ref HomeIops, !Ref "AWS::NoValue"]
             DeleteOnTermination: !Ref HomeDeleteOnTermination
+            Iops: !If [IsHomeProvisionedIops, !Ref HomeIops, !Ref "AWS::NoValue"]
             SnapshotId: !If [RestoreFromEBSSnapshot, !Ref HomeVolumeSnapshotId, !Ref "AWS::NoValue"]
             VolumeSize: !Ref HomeSize
+            VolumeType: !If [IsHomeProvisionedIops, io1, gp2]
         - DeviceName: /dev/sdf
           NoDevice: {}
       IamInstanceProfile: !Ref BitbucketFileServerInstanceProfile
@@ -982,7 +981,7 @@ Resources:
       NetworkInterfaces:
         - GroupSet: [!Ref SecurityGroup]
           AssociatePublicIpAddress: false
-          DeviceIndex: 0
+          DeviceIndex: '0'
           DeleteOnTermination: true
           SubnetId: !Select [0, !Split [ ",", !ImportValue ATL-PriNets] ]
       Tags:
@@ -1012,10 +1011,10 @@ Resources:
       DBSnapshotIdentifier: !If [RestoreFromRDSSnapshot, !Ref DBSnapshotId, !Ref "AWS::NoValue"]
       DBSubnetGroupName: !Ref DBSubnetGroup
       Engine: postgres
-      EngineVersion: 10
+      EngineVersion: '10'
       Iops: !If [DBProvisionedIops, !Ref DBIops, !Ref "AWS::NoValue"]
-      MasterUsername: postgres
-      MasterUserPassword: !If [SetDBMasterUserPassword, !Ref DBMasterUserPassword, !Ref "AWS::NoValue"]
+      MasterUsername: !If ["SetDBMasterUserAndPassword", postgres, !Ref "AWS::NoValue"]
+      MasterUserPassword: !If ["SetDBMasterUserAndPassword", !Ref DBMasterUserPassword, !Ref "AWS::NoValue"]
       MultiAZ: !If [StandbyMode, !Ref "AWS::NoValue", !Ref DBMultiAZ]
       StorageType: !If [DBProvisionedIops, io1, gp2]
       SourceDBInstanceIdentifier: !If [StandbyMode, !Ref DBMaster, !Ref "AWS::NoValue"]
@@ -1041,31 +1040,31 @@ Resources:
         IdleTimeout: 3600
       CrossZone: true
       Listeners:
-        - LoadBalancerPort: 80
+        - LoadBalancerPort: '80'
           Protocol: HTTP
-          InstancePort: !If [DoSSL, 7991, 7990]
+          InstancePort: !If [DoSSL, '7991', '7990']
           InstanceProtocol: HTTP
           PolicyNames: [SessionStickiness]
         - !If
           - DoSSL
-          - LoadBalancerPort: 443
+          - LoadBalancerPort: '443'
             Protocol: HTTPS
-            InstancePort: 7990
+            InstancePort: '7990'
             InstanceProtocol: HTTP
             PolicyNames:
               - SessionStickiness
             SSLCertificateId: !Ref SSLCertificateARN
           - !Ref AWS::NoValue
-        - LoadBalancerPort: 7999
+        - LoadBalancerPort: '7999'
           Protocol: TCP
-          InstancePort: 7999
+          InstancePort: '7999'
           InstanceProtocol: TCP
       HealthCheck:
-        HealthyThreshold: 2
-        Interval: 60
+        HealthyThreshold: '2'
+        Interval: '60'
         Target: HTTP:7990/status
-        Timeout: 29
-        UnhealthyThreshold: 2
+        Timeout: '29'
+        UnhealthyThreshold: '2'
       Scheme: !If [UsePublicIp, 'internet-facing', 'internal']
       SecurityGroups: [!Ref SecurityGroup]
       Subnets: !Split [ ",", !ImportValue ATL-PubNets]
@@ -1104,8 +1103,8 @@ Resources:
     Properties:
       GroupId: !Ref SecurityGroup
       IpProtocol: '-1'
-      FromPort: '-1'
-      ToPort: '-1'
+      FromPort: -1
+      ToPort: -1
       SourceSecurityGroupId: !Ref SecurityGroup
 Outputs:
   ClusterNodeGroup:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -291,12 +291,6 @@ Parameters:
     Default: ""
     Type: String
     Description: Named KeyPair name to use with this repository. The key should be imported into the SSM parameter store. (Optional)
-  ESSnapshotId:
-    Default: ''
-    AllowedPattern: '[a-z0-9-]*'
-    ConstraintDescription: Must contain only lowercase letters, numbers and hyphens (-).
-    Description: Must be a valid snapshot ID for a snapshot in the configured S3 snapshot repository, must be used in conjunction with ESBucketName set to a correctly configured bucket.
-    Type: String
   DBInstanceClass:
     Default: db.m4.large
     AllowedValues:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -767,9 +767,6 @@ Resources:
 
     Properties:
       AssociatePublicIpAddress: false
-      BlockDeviceMappings:
-        - DeviceName: /dev/sdf
-          NoDevice: true
       KeyName: !If [ KeyProvided, !Ref KeyPairName, !ImportValue ATL-DefaultKey ]
       IamInstanceProfile: !Ref BitbucketClusterNodeInstanceProfile
       ImageId:
@@ -880,7 +877,7 @@ Resources:
                   - ATL_ENABLED_PRODUCTS=
                   - ATL_ENABLED_SHARED_HOMES=Bitbucket
                   - ATL_APP_NFS_SERVER=true
-                  - ATL_NFS_SERVER_DEVICE=/dev/sdf
+                  - ATL_NFS_SERVER_DEVICE=/dev/xvdf
                   # NOTE: For simplicity we should keep this as close to the BB node version above.
                   - !Sub ["ATL_PRODUCT_VERSION=${BitbucketVersion}", BitbucketVersion: !Ref BitbucketVersion]
                   - !Sub ["ATL_PROXY_NAME=${LoadBalancerDNSName}", LoadBalancerDNSName: !GetAtt LoadBalancer.DNSName]
@@ -960,15 +957,12 @@ Resources:
 
     Properties:
       BlockDeviceMappings:
-        - DeviceName: /dev/sdf
+        - DeviceName: /dev/xvdf
           Ebs:
             DeleteOnTermination: !Ref HomeDeleteOnTermination
             Iops: !If [IsHomeProvisionedIops, !Ref HomeIops, !Ref "AWS::NoValue"]
             SnapshotId: !If [RestoreFromEBSSnapshot, !Ref HomeVolumeSnapshotId, !Ref "AWS::NoValue"]
             VolumeSize: !Ref HomeSize
-            VolumeType: !If [IsHomeProvisionedIops, io1, gp2]
-        - DeviceName: /dev/sdf
-          NoDevice: {}
       IamInstanceProfile: !Ref BitbucketFileServerInstanceProfile
       EbsOptimized: true
       ImageId:


### PR DESCRIPTION
*Description of changes:*
* Added default `taskcat` param file
* Quoted JDBC and Postgres passwords in `/etc/atl` - DCD-547
* Workaround for autogenerated `taskcat` passwords containing forbidden characters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
