### PR TITLE
DCD-945: Use single AZ for Bitbucket application nodes

### DIFF
--- a/ci/params/3nodes/quickstart-bitbucket-3nodes.json
+++ b/ci/params/3nodes/quickstart-bitbucket-3nodes.json
@@ -1,0 +1,54 @@
+[
+  {
+    "ParameterKey": "DBMultiAZ",
+    "ParameterValue": "false"
+  },
+  {
+    "ParameterKey": "BitbucketVersion",
+    "ParameterValue": "6.8.1"
+  },
+  {
+    "ParameterKey": "DBMasterUserPassword",
+    "ParameterValue": "f925dO1ry_"
+  },
+  {
+    "ParameterKey": "CidrBlock",
+    "ParameterValue": "0.0.0.0/0"
+  },
+  {
+    "ParameterKey": "DBIops",
+    "ParameterValue": "1000"
+  },
+  {
+    "ParameterKey": "DBPassword",
+    "ParameterValue": "f925dO1ry_"
+  },
+  {
+    "ParameterKey": "KeyPairName",
+    "ParameterValue": "replaced-by-taskcat-override-file"
+  },
+  {
+    "ParameterKey": "ClusterNodeInstanceType",
+    "ParameterValue": "t3.medium"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.t3.medium"
+  },
+  {
+    "ParameterKey": "QSS3BucketName",
+    "ParameterValue": "$[taskcat_autobucket]"
+  },
+  {
+    "ParameterKey": "QSS3KeyPrefix",
+    "ParameterValue": "quickstart-atlassian-bitbucket/"
+  },
+  {
+    "ParameterKey": "ClusterNodeMin",
+    "ParameterValue": "3"
+  },
+  {
+    "ParameterKey": "ClusterNodeMax",
+    "ParameterValue": "3"
+  }
+]

--- a/ci/params/3nodes/taskcat.yml
+++ b/ci/params/3nodes/taskcat.yml
@@ -1,0 +1,26 @@
+---
+global:
+  qsname: quickstart-atlassian-bitbucket
+  owner: quickstart-eng@amazon.com
+  marketplace-ami: false
+  reporting: true
+  regions:
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - eu-central-1
+    - eu-west-1
+    - sa-east-1
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+
+tests:
+  BB-5:
+    template_file: quickstart-bitbucket-dc.template.yaml
+    parameter_input: params/3nodes/quickstart-bitbucket-3nodes.json
+    regions:
+    - us-east-1

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -744,9 +744,12 @@ Resources:
       MinSize: !If [StandbyMode, '0', !Ref ClusterNodeMin]
       MaxSize: !Ref ClusterNodeMax
       LoadBalancerNames: [!Ref LoadBalancer]
-      VPCZoneIdentifier: !Split
-        - ","
-        - Fn::ImportValue: !Sub "${ExportPrefix}PriNets"
+      VPCZoneIdentifier:
+        - !Select
+          - 0
+          - !Split
+            - ','
+            - Fn::ImportValue: !Sub '${ExportPrefix}PriNets'
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName} Bitbucket Node"


### PR DESCRIPTION
DCD-945: Use single AZ for Bitbucket application nodes

*Description of changes:*
Application nodes were supposed to run only in single Availability Zone. This change creates all Bitbucket nodes in the same AZ as FileServer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
