### PR TITLE
Remove unnecessary DatabaseIdentifier

### DIFF
--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -1284,7 +1284,6 @@ Resources:
         ProductStackName: !Sub "${AWS::StackName}"
         ProductFamilyName: "bitbucket"
         AsgToMonitor: !Ref ClusterNodeGroup
-        DatabaseIdentifier: !If [ DBEngineAurora, !Ref DBCluster, !Ref DB ]
 
 Outputs:
   ClusterNodeGroup:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`DatabaseIdentifier` was removed from ASI and the change wasn't reflected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
