### PR TITLE
DCD-961: fixed KeyPairName parameter

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -526,8 +526,8 @@ Parameters:
     Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances. If you don't provide one, the Atlassian Standard Infrastructure stack's key pair will be used.
-    Type: String
+    Description: The EC2 Key Pair to allow SSH access to the instances. 
+    Type: List<AWS::EC2::Keypair>
     Default: ''
   CustomDnsName:
     Default: ""

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -509,7 +509,7 @@ Parameters:
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
     Description: The EC2 Key Pair to allow SSH access to the instances. If you don't provide one, the Atlassian Standard Infrastructure stack's key pair will be used.
-    Type: String
+    Type: List<AWS::EC2::Keypair>
     Default: ''
   CustomDnsName:
     Default: ""


### PR DESCRIPTION
When deploying with an ASI, the KeyPairName is always required. When deploying into an existing ASI, you have the option to just use that ASI's key pair. This corrects the description for the parameter in both templates.

Also, the type is now a drop-down list (it used to be a simple String).
