### PR TITLE
DCD-954: Add bastion to EC2 security group

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -526,8 +526,8 @@ Parameters:
     Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances. If you don't provide one, the Atlassian Standard Infrastructure stack's key pair will be used.
-    Type: String
+    Description: The EC2 Key Pair to allow SSH access to the instances. 
+    Type: List<AWS::EC2::Keypair>
     Default: ''
   CustomDnsName:
     Default: ""

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -526,8 +526,8 @@ Parameters:
     Type: String
   KeyPairName:
     ConstraintDescription: Must be the name of an existing EC2 Key Pair.
-    Description: The EC2 Key Pair to allow SSH access to the instances. 
-    Type: List<AWS::EC2::Keypair>
+    Description: The EC2 Key Pair to allow SSH access to the instances.
+    Type: AWS::EC2::KeyPair::KeyName
     Default: ''
   CustomDnsName:
     Default: ""

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -1236,6 +1236,14 @@ Resources:
           ToPort: 7999
           CidrIp: !Ref CidrBlock
         - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp:
+            !Sub
+              - "${BastionIp}/32"
+              - BastionIp:
+                  Fn::ImportValue: !Sub '${ExportPrefix}BastionPrivIp'
+        - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
           CidrIp:


### PR DESCRIPTION
Imports the private IP of the bastion host from the ASI so that when CidrBlock is set the Bastion can still SSH to the webserver.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.