### PR TITLE
Ensure db instance name is within character limit

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -1,0 +1,35 @@
+project:
+  name: quickstart-atlassian-bitbucket
+  owner: quickstart-eng@amazon.com
+  package_lambda: false
+  regions:
+  - ap-northeast-1
+  - ap-northeast-2
+  - ap-south-1
+  - ap-southeast-1
+  - ap-southeast-2
+  - eu-central-1
+  - eu-west-1
+  - sa-east-1
+  - us-east-1
+  - us-east-2
+  - us-west-1
+  - us-west-2
+  s3_bucket: ''
+tests:
+  BB-5:
+    parameters:
+      CidrBlock: 10.0.0.0/0
+      BitbucketVersion: 6.6.0
+      DBInstanceClass: db.t2.large
+      DBIops: '1000'
+      DBMasterUserPassword: f925dO1ry_
+      DBMultiAZ: 'false'
+      DBPassword: f925dO1ry_
+      KeyPairName: replaced-by-taskcat-override-file
+      QSS3BucketName: $[taskcat_autobucket]
+      QSS3KeyPrefix: quickstart-atlassian-bitbucket/
+    regions:
+    - us-east-1
+    s3_bucket: ''
+    template: templates/quickstart-bitbucket-dc.template.yaml

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -181,7 +181,7 @@ Parameters:
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
     Type: CommaDelimitedList
   BitbucketVersion:
-    Default: 6.10.0
+    Default: "6.10.0"
     AllowedPattern: '([^1234]\.\d+\.\d+(-?.*))'
     ConstraintDescription: 'Must be a valid Bitbucket version number. For example: 5.0.0 or higher'
     Description: 'Version of Bitbucket to install. Please use version 5.0.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases'
@@ -306,8 +306,8 @@ Parameters:
     Description: Set to 1 for new deployment. Can be updated post launch.
     Type: Number
   CreateBucket:
-    Default: true
-    AllowedValues: [true, false]
+    Default: "true"
+    AllowedValues: ["true", "false"]
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Set to true to create the S3 bucket within this stack, must be used in conjunction with ESBucketName.
     Type: String
@@ -396,10 +396,10 @@ Parameters:
     Type: String
   DBMultiAZ:
     Description: Whether to provision a multi-AZ RDS instance.
-    Default: true
+    Default: "true"
     AllowedValues:
-      - true
-      - false
+      - "true"
+      - "false"
     ConstraintDescription: Must be 'true' or 'false'.
     Type: String
   DBPassword:
@@ -469,7 +469,7 @@ Parameters:
   ExportPrefix:
     Default: 'ATL-'
     Description:
-      Identifier used in all variables (VPCID, SubnetIDs, KeyName) exported from this deployment's Atlassian Standard Infrastructure. Use different identifiers if you're deploying multiple Atlassian Standard Infrastructures in the same AWS region.
+      Each Atlassian Standard Infrastructure (ASI) uses a unique identifier. If you have multiple ASIs within the same AWS region, use this field to specify where to deploy Bitbucket.
     Type: String
   FileServerInstanceType:
     Default: m4.xlarge
@@ -488,8 +488,8 @@ Parameters:
     Description: Instance type for the file server hosting the Bitbucket shared home directory. See https://confluence.atlassian.com/x/GpdKLg for guidance
     Type: String
   HomeDeleteOnTermination:
-    Default: true
-    AllowedValues: [true, false]
+    Default: "true"
+    AllowedValues: ["true", "false"]
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Delete Bitbucket home directory volume when the file server instance is terminated.  You must back up your data before terminating your file server instance if this option is set to 'true'
     Type: String
@@ -519,8 +519,8 @@ Parameters:
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Type: String
   InternetFacingLoadBalancer:
-    Default: true
-    AllowedValues: [true, false]
+    Default: "true"
+    AllowedValues: ["true", "false"]
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
     Type: String

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -163,7 +163,7 @@ Parameters:
     Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
     Type: CommaDelimitedList
   BitbucketVersion:
-    Default: 6.10.0
+    Default: "6.10.0"
     AllowedPattern: '([^1234]\.\d+\.\d+(-?.*))'
     ConstraintDescription: 'Must be a valid Bitbucket version number. For example: 5.0.0 or higher'
     Description: 'Version of Bitbucket to install. Please use version 5.0.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases'
@@ -280,8 +280,8 @@ Parameters:
     Description: Set to 1 for new deployment. Can be updated post launch.
     Type: Number
   CreateBucket:
-    Default: true
-    AllowedValues: [true, false]
+    Default: "true"
+    AllowedValues: ["true", "false"]
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Set to true to create the S3 bucket within this stack, must be used in conjunction with ESBucketName.
     Type: String
@@ -370,10 +370,10 @@ Parameters:
     Type: String
   DBMultiAZ:
     Description: Whether to provision a multi-AZ RDS instance.
-    Default: true
+    Default: "true"
     AllowedValues:
-      - true
-      - false
+      - "true"
+      - "false"
     ConstraintDescription: Must be 'true' or 'false'.
     Type: String
   DBPassword:
@@ -462,8 +462,8 @@ Parameters:
     Description: Instance type for the file server hosting the Bitbucket shared home directory. See https://confluence.atlassian.com/x/GpdKLg for guidance
     Type: String
   HomeDeleteOnTermination:
-    Default: true
-    AllowedValues: [true, false]
+    Default: "true"
+    AllowedValues: ["true", "false"]
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Delete Bitbucket home directory volume when the file server instance is terminated.  You must back up your data before terminating your file server instance if this option is set to 'true'
     Type: String
@@ -493,8 +493,8 @@ Parameters:
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Type: String
   InternetFacingLoadBalancer:
-    Default: true
-    AllowedValues: [true, false]
+    Default: "true"
+    AllowedValues: ["true", "false"]
     ConstraintDescription: Must be 'true' or 'false'.
     Description: Controls whether the load balancer should be visible to the internet (true) or only within the VPC (false).
     Type: String

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -1115,13 +1115,64 @@ Resources:
             - !Sub [" --resource FileServer --region ${Region}\n", Region: !Ref "AWS::Region"]
             - !Sub ["/opt/aws/bin/cfn-signal -e $? --stack ${StackName}", StackName: !Ref "AWS::StackName"]
             - !Sub [" --resource FileServer --region ${Region}\n", Region: !Ref "AWS::Region"]
+
+  ## We need a custom resource to generate a meaningful name. If the stack name
+  ## is longer than 57 characters, using {StackName}-db would cause a deployment failure
+  DbInstanceName:
+    Condition: DBEnginePostgres
+    Type: Custom::DbInstanceName
+    Version: 1.0
+    Properties:
+      ServiceToken: !GetAtt DBNameGenerator.Arn
+      StackName: !Ref 'AWS::StackName'
+  DBNameGenerator:
+    Condition: DBEnginePostgres
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Handler: index.lambda_handler
+      Role: !GetAtt DBNameGeneratorExecutionRole.Arn
+      Runtime: python3.7
+      Timeout: 120
+      Code:
+        ZipFile: |
+          import cfnresponse
+          def lambda_handler(event, context):
+            stack_name = event['ResourceProperties']['StackName']
+            responseData = {}
+            responseData['DBInstanceName'] = stack_name[:57] + "-db"
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
+  DBNameGeneratorExecutionRole:
+    Condition: DBEnginePostgres
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: "/"
+      Policies:
+      - PolicyName: root
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+            Resource: !Sub "arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/lambda/*DBNameGenerator*"
   DB:
     Type: AWS::RDS::DBInstance
     Condition: DBEnginePostgres
     Properties:
       AllocatedStorage: !Ref DBStorage
       DBInstanceClass: !Ref DBInstanceClass
-      DBInstanceIdentifier: !Ref AWS::StackName
+      DBInstanceIdentifier: !GetAtt DbInstanceName.DBInstanceName
       DBName: !If [RestoreRDSOrStandby, !Ref "AWS::NoValue", bitbucket]
       DBSnapshotIdentifier: !If [RestoreFromRDSSnapshot, !Ref DBSnapshotId, !Ref "AWS::NoValue"]
       DBSubnetGroupName: !Ref DBSubnetGroup


### PR DESCRIPTION
Using the stack name as the db instance identifier doesn't work if the stack name is longer than 60 chars. We use a custom resource to trim it down.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
