### PR TITLE
DCD-1051: Gov arn for gov region

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -23,6 +23,7 @@ tests:
       AvailabilityZones: $[taskcat_genaz_2]
       BitbucketVersion: "6.6.0"
       DBMasterUserPassword: $[taskcat_genpass_10S]
+      BitbucketAdminPassword: "replaced-by-taskcat-override-file"
       AccessCIDR: "10.0.0.0/0"
       DBMultiAZ: "false"
       DBInstanceClass: db.t2.large

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -2,6 +2,7 @@ project:
   name: quickstart-atlassian-bitbucket
   owner: quickstart-eng@amazon.com
   package_lambda: false
+  s3_regional_buckets: true
   regions:
   - ap-northeast-1
   - ap-northeast-2


### PR DESCRIPTION
Ran custom Jira CI plan (temporarily updated Jira submodules to point to updated quickstart-atlassian-services and updated quickstart-amazon-aurora) results for which are below:

https://server-syd-bamboo.internal.atlassian.com/browse/DCD-AWSJIRA64-JSMOKDEPLOY-9/log

Deploys passed and all but the HTTP acceptance tests which I believe to be a dud (looking at the logs). This run should confirm these AWS partition changes across the board for Jira and the other products; BB, Connie, Crowd

These changes have also been tested in a Gov account and are shown to work, where we no longer have failing deployments