### PR TITLE
Fix Aurora restore permissions and config

### DIFF
--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -752,13 +752,22 @@ Resources:
                   - 'ec2:DescribeVolumes'
                   - 'ec2:DetachVolume'
                   - 'rds:AddTagsToResource'
+                  - 'rds:CopyDBClusterSnapshot'
                   - 'rds:CopyDBSnapshot'
+                  - 'rds:CreateDBClusterSnapshot'
+                  - 'rds:CreateDBInstance'
                   - 'rds:CreateDBSnapshot'
+                  - 'rds:DeleteDBClusterSnapshot'
                   - 'rds:DeleteDBSnapshot'
+                  - 'rds:DescribeDBClusters'
                   - 'rds:DescribeDBInstances'
+                  - 'rds:DescribeDBClusterSnapshots'
                   - 'rds:DescribeDBSnapshots'
                   - 'rds:PromoteReadReplica'
+                  - 'rds:ModifyDBCluster'
+                  - 'rds:ModifyDBClusterSnapshotAttribute'
                   - 'rds:ModifyDBInstance'
+                  - 'rds:RestoreDBClusterFromSnapshot'
                   - 'rds:RestoreDBInstanceFromDBSnapshot'
                   - 'iam:PassRole'
                   - 'es:*'
@@ -886,11 +895,12 @@ Resources:
                   - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !If [DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointPort, !GetAtt DB.Endpoint.Port]]
                   - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/bitbucket", { DBEndpointAddress: !If [DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointAddress, !GetAtt DB.Endpoint.Address], DBEndpointPort: !If [DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointPort, !GetAtt DB.Endpoint.Port]}]
                   - ""
-                  - !Sub ["ATL_RDS_INSTANCE_ID=${DB}", DB: !If [ DBEngineAurora, !Ref "DBCluster", !Ref "DB"]]
+                  - !Sub ["ATL_RDS_INSTANCE_ID=${DB}", DB: !If [ DBEngineAurora, !GetAtt DBCluster.Outputs.RDSIdentifier, !Ref "DB"]]
                   - !Sub ["ATL_RDS_INSTANCE_CLASS=${DBInstanceClass}", DBInstanceClass: !Ref "DBInstanceClass"]
                   - !Sub ["ATL_RDS_MULTI_AZ=${DBMultiAZ}", DBMultiAZ: !Ref "DBMultiAZ"]
                   - !Sub ["ATL_RDS_SUBNET_GROUP_NAME=${DBSubnetGroup}", DBSubnetGroup: !If [ DBEnginePostgres, !Ref "DBSubnetGroup", '']]
                   - !Sub ["ATL_RDS_SECURITY_GROUP=${SecurityGroup}", SecurityGroup: !Ref "SecurityGroup"]
+                  - !Sub ["ATL_RDS_TYPE=${DBType}", DBType: !If [ DBEngineAurora, "aurora", "rds"]]
                   - ""
                   - !Sub ["ATL_NFS_DISK_VOLUME_TYPE=${VolType}", VolType: !If [IsHomeProvisionedIops, "io1", "gp2"]]
                   - !Sub ["ATL_NFS_DISK_VOLUME_IOPS=${VolIOPs}", VolIOPs: !If [IsHomeProvisionedIops, !Ref "HomeIops", ""]]
@@ -1095,11 +1105,12 @@ Resources:
                   - !Sub ["ATL_DB_PORT=${DBEndpointPort}", DBEndpointPort: !If [ DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointPort, !GetAtt DB.Endpoint.Port]]
                   - !Sub ["ATL_JDBC_URL=jdbc:postgresql://${DBEndpointAddress}:${DBEndpointPort}/bitbucket", { DBEndpointAddress: !If [ DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointAddress, !GetAtt DB.Endpoint.Address], DBEndpointPort: !If [ DBEngineAurora, !GetAtt DBCluster.Outputs.RDSEndPointPort, !GetAtt DB.Endpoint.Port] }]
                   - ""
-                  - !Sub ["ATL_RDS_INSTANCE_ID=${DB}", DB: !If [ DBEngineAurora, !Ref "DBCluster", !Ref "DB"]]
+                  - !Sub ["ATL_RDS_INSTANCE_ID=${DB}", DB: !If [ DBEngineAurora, !GetAtt DBCluster.Outputs.RDSIdentifier, !Ref "DB"]]
                   - !Sub ["ATL_RDS_INSTANCE_CLASS=${DBInstanceClass}", DBInstanceClass: !Ref "DBInstanceClass"]
                   - !Sub ["ATL_RDS_MULTI_AZ=${DBMultiAZ}", DBMultiAZ: !Ref "DBMultiAZ"]
                   - !Sub ["ATL_RDS_SUBNET_GROUP_NAME=${DBSubnetGroup}", DBSubnetGroup: !If [ DBEnginePostgres, !Ref "DBSubnetGroup", '']]
                   - !Sub ["ATL_RDS_SECURITY_GROUP=${SecurityGroup}", SecurityGroup: !Ref "SecurityGroup"]
+                  - !Sub ["ATL_RDS_TYPE=${DBType}", DBType: !If [ DBEngineAurora, "aurora", "rds"]]
                   - ""
                   - !Sub ["ATL_NFS_DISK_VOLUME_TYPE=${VolType}", VolType: !If [IsHomeProvisionedIops, "io1", "gp2"]]
                   - !Sub ["ATL_NFS_DISK_VOLUME_IOPS=${VolIOPs}", VolIOPs: !If [IsHomeProvisionedIops, !Ref "HomeIops", ""]]


### PR DESCRIPTION
*Description of changes:*

Issue: the diy_backup tool's functionality did not work out of the box, when the chosen database was RDS Aurora.
Permissions were lacking, and config was wrong.

This pull request grants the FileServerRole all required permissions to back up and restore an Aurora Cluster, and also fixes some configuration in /etc/atl. It depends on the pull requests of the submodules to export the RDS identifier.

**Related PRs:**

Ansible playbook:
- https://bitbucket.org/atlassian/dc-deployments-automation/pull-requests/111/diy_backup-config-for-aurora-optional-es/diff

Submodules:

- https://github.com/aws-quickstart/quickstart-atlassian-services/pull/46
- https://github.com/aws-quickstart/quickstart-amazon-aurora-postgresql/pull/38

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
