### PR TITLE
DCD-1190: Change the BitbucketProperties to a simple space-delimited string

### DIFF
--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -196,8 +196,8 @@ Metadata:
 Parameters:
   BitbucketProperties:
     Default: ''
-    Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
-    Type: CommaDelimitedList
+    Description: A space-separated list of bitbucket properties in the form 'key1=value1 key2=value2 ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
+    Type: String
   BitbucketVersion:
     Default: "6.10.0"
     AllowedPattern: '([^1234]\.\d+\.\d+(-?.*))'
@@ -679,9 +679,7 @@ Resources:
             - s3
       Parameters:
         InternetFacingLoadBalancer: !Ref 'InternetFacingLoadBalancer'
-        BitbucketProperties: !Join
-          - ','
-          - !Ref 'BitbucketProperties'
+        BitbucketProperties: !Ref 'BitbucketProperties'
         BitbucketVersion: !Ref 'BitbucketVersion'
         BitbucketLicenseKey: !Ref 'BitbucketLicenseKey'
         BitbucketAdminPassword: !Ref 'BitbucketAdminPassword'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -177,8 +177,8 @@ Metadata:
 Parameters:
   BitbucketProperties:
     Default: ''
-    Description: A comma-separated list of bitbucket properties in the form 'key1=value1, key2=value2, ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
-    Type: CommaDelimitedList
+    Description: A space-separated list of bitbucket properties in the form 'key1=value1 key2=value2 ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
+    Type: String
   BitbucketVersion:
     Default: "6.10.0"
     AllowedPattern: '([^1234]\.\d+\.\d+(-?.*))'
@@ -875,7 +875,7 @@ Resources:
                   - ""
                   - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
                   - !Sub ["ATL_ELASTICSEARCH_ENDPOINT=http://${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
-                  - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Join ["\\\n", !Ref BitbucketProperties]]
+                  - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Ref BitbucketProperties]
                   - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]
 
                   - !Sub ["ATL_AWS_ENABLE_CLOUDWATCH=${EnableCW}", EnableCW: !If [EnableCloudWatch, true, false]]
@@ -1088,7 +1088,7 @@ Resources:
                   - ""
                   - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
                   - !Sub ["ATL_ELASTICSEARCH_S3_BUCKET=${BucketName}", BucketName: !Ref ESBucketName]
-                  - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Join ["\\\n", !Ref BitbucketProperties]]
+                  - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Ref BitbucketProperties]
                   - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]
                   - ""
                   - !Sub ["ATL_DEPLOYMENT_REPOSITORY=${DeployRepository}", DeployRepository: !Ref "DeploymentAutomationRepository"]


### PR DESCRIPTION
The valid bitbucket.properties values can include commas (e.g hazelcast.network.tcpip.members), so using a comma-separated list will mangle these. Move to spaces, and leave decoding to the playbook roles. There are no backwards-compatibility issues with this change as we never honoured this parameter, and it wouldn't have worked anyway, as the current encoding in /etc/atl strips any delimiters.

There is a corresponding PR in the playbook repository.