### PR TITLE
February Quick Start Updates

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -10,4 +10,4 @@ ignore_checks:
   - E3012
     # E3012: Property Resources/EFSCname/Properties/TTL should be of type Long
   - E1001
-    # E1001: Top level template section tests is not valid
+    # E1001: Top level template section tests is not valid.

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 [submodule "docs/boilerplate"]
 	path = docs/boilerplate
 	url = git@github.com:aws-quickstart/quickstart-documentation-base-common
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = main
 [submodule "docs/boilerplate"]
 	path = docs/boilerplate
-	url = git@github.com:aws-quickstart/quickstart-documentation-base-common
+	url = https://github.com/aws-quickstart/quickstart-documentation-base-common.git
 	branch = main

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -23,6 +23,7 @@ tests:
       AvailabilityZones: $[taskcat_genaz_2]
       BitbucketVersion: "6.6.0"
       DBMasterUserPassword: $[taskcat_genpass_10S]
+      ElasticSearchPassword: $[taskcat_genpass_10S]
       BitbucketAdminPassword: "replaced-by-taskcat-override-file"
       AccessCIDR: "10.0.0.0/0"
       DBMultiAZ: "false"

--- a/ci/params/3nodes/quickstart-bitbucket-3nodes.json
+++ b/ci/params/3nodes/quickstart-bitbucket-3nodes.json
@@ -12,6 +12,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "BitbucketAdminPassword",
     "ParameterValue": ""
   },

--- a/ci/params/aurora/quickstart-bitbucket-dc-aurora-params.json
+++ b/ci/params/aurora/quickstart-bitbucket-dc-aurora-params.json
@@ -16,6 +16,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "QSS3BucketName",
     "ParameterValue": "$[taskcat_autobucket]"
   },

--- a/ci/params/automated-setup/quickstart-bitbucket-automated-setup.json
+++ b/ci/params/automated-setup/quickstart-bitbucket-automated-setup.json
@@ -36,6 +36,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/dbVersions/quickstart-bitbucket-aurora-10.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-aurora-10.json
@@ -36,6 +36,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/dbVersions/quickstart-bitbucket-aurora-12.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-aurora-12.json
@@ -36,6 +36,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/dbVersions/quickstart-bitbucket-aurora-12.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-aurora-12.json
@@ -17,7 +17,7 @@
   },
   {
     "ParameterKey": "DBEngineVersion",
-    "ParameterValue": "11"
+    "ParameterValue": "12"
   },
   {
     "ParameterKey": "DBInstanceClass",

--- a/ci/params/dbVersions/quickstart-bitbucket-postgres-10.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-postgres-10.json
@@ -32,6 +32,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/dbVersions/quickstart-bitbucket-postgres-11.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-postgres-11.json
@@ -32,6 +32,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/dbVersions/quickstart-bitbucket-postgres-12.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-postgres-12.json
@@ -17,7 +17,7 @@
   },
   {
     "ParameterKey": "DBEngineVersion",
-    "ParameterValue": "10"
+    "ParameterValue": "12"
   },
   {
     "ParameterKey": "DBEngine",

--- a/ci/params/dbVersions/quickstart-bitbucket-postgres-12.json
+++ b/ci/params/dbVersions/quickstart-bitbucket-postgres-12.json
@@ -32,6 +32,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/default/quickstart-bitbucket-default.json
+++ b/ci/params/default/quickstart-bitbucket-default.json
@@ -24,6 +24,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/insecure-search/quickstart-bitbucket-default.json
+++ b/ci/params/insecure-search/quickstart-bitbucket-default.json
@@ -16,27 +16,11 @@
     "ParameterValue": "0.0.0.0/0"
   },
   {
-    "ParameterKey": "DBEngineVersion",
-    "ParameterValue": "11"
-  },
-  {
-    "ParameterKey": "DBInstanceClass",
-    "ParameterValue": "db.t3.medium"
-  },
-  {
-    "ParameterKey": "DBEngine",
-    "ParameterValue": "Amazon Aurora PostgreSQL"
-  },
-  {
     "ParameterKey": "DBIops",
     "ParameterValue": "1000"
   },
   {
     "ParameterKey": "DBPassword",
-    "ParameterValue": "$[taskcat_genpass_8S]"
-  },
-  {
-    "ParameterKey": "ElasticSearchPassword",
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
@@ -46,6 +30,10 @@
   {
     "ParameterKey": "ClusterNodeInstanceType",
     "ParameterValue": "t3.medium"
+  },
+  {
+    "ParameterKey": "DBInstanceClass",
+    "ParameterValue": "db.t3.medium"
   },
   {
     "ParameterKey": "QSS3BucketName",

--- a/ci/params/insecure-search/taskcat.yml
+++ b/ci/params/insecure-search/taskcat.yml
@@ -1,0 +1,26 @@
+---
+global:
+  qsname: quickstart-atlassian-bitbucket
+  owner: quickstart-eng@amazon.com
+  marketplace-ami: false
+  reporting: true
+  regions:
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - eu-central-1
+    - eu-west-1
+    - sa-east-1
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+
+tests:
+  BB-10:
+    template_file: quickstart-bitbucket-dc.template.yaml
+    parameter_input: params/insecure-search/quickstart-bitbucket-default.json
+    regions:
+     - us-east-1

--- a/ci/params/jvm-support-opts/quickstart-bitbucket-jvm-support-opts.json
+++ b/ci/params/jvm-support-opts/quickstart-bitbucket-jvm-support-opts.json
@@ -24,6 +24,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "KeyPairName",
     "ParameterValue": "replaced-by-taskcat-override-file"
   },

--- a/ci/params/no-bastion/quickstart-bitbucket-no-bastion.json
+++ b/ci/params/no-bastion/quickstart-bitbucket-no-bastion.json
@@ -4,10 +4,6 @@
     "ParameterValue": "$[taskcat_genaz_2]"
   },
   {
-    "ParameterKey": "BitbucketVersion",
-    "ParameterValue": "6.10.0"
-  },
-  {
     "ParameterKey": "DBMasterUserPassword",
     "ParameterValue": "$[taskcat_genpass_8S]"
   },

--- a/ci/params/no-bastion/quickstart-bitbucket-no-bastion.json
+++ b/ci/params/no-bastion/quickstart-bitbucket-no-bastion.json
@@ -32,6 +32,10 @@
     "ParameterValue": "$[taskcat_genpass_8S]"
   },
   {
+    "ParameterKey": "ElasticSearchPassword",
+    "ParameterValue": "$[taskcat_genpass_8S]"
+  },
+  {
     "ParameterKey": "BastionHostRequired",
     "ParameterValue": "false"
   },

--- a/ci/params/ssl-and-dns/quickstart-bitbucket-ci-params.json
+++ b/ci/params/ssl-and-dns/quickstart-bitbucket-ci-params.json
@@ -20,6 +20,10 @@
         "ParameterValue": "$[taskcat_genpass_8S]"
     },
     {
+        "ParameterKey": "ElasticSearchPassword",
+        "ParameterValue": "$[taskcat_genpass_8S]"
+      },
+    {
         "ParameterKey": "DBStorage",
         "ParameterValue": "100"
     },

--- a/ci/quickstart-bitbucket-master.json
+++ b/ci/quickstart-bitbucket-master.json
@@ -4,10 +4,6 @@
         "ParameterValue": "$[taskcat_genaz_2]"
     },
     {
-        "ParameterKey": "BitbucketVersion",
-        "ParameterValue": "6.10.0"
-    },
-    {
         "ParameterKey": "DBMasterUserPassword",
         "ParameterValue": "$[taskcat_genpass_8S]"
     },

--- a/ci/quickstart-bitbucket-master.json
+++ b/ci/quickstart-bitbucket-master.json
@@ -32,6 +32,10 @@
         "ParameterValue": "$[taskcat_genpass_8S]"
     },
     {
+        "ParameterKey": "ElasticSearchPassword",
+        "ParameterValue": "$[taskcat_genpass_8S]"
+    },
+    {
         "ParameterKey": "KeyPairName",
         "ParameterValue": "replaced-by-taskcat-override-file"
     },

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -2,6 +2,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: "Atlassian Bitbucket Data Center in new VPC License: Apache 2.0 (qs-1qup6r9tq)"
 Metadata:
+  QuickStartDocumentation:
+    EntrypointName: "Launch into a new VPC"
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -44,7 +44,7 @@ Metadata:
           - DBStorageType
       - Label:
           default: Bastion host provisioning
-          Parameters:
+        Parameters:
             - BastionHostRequired
             - KeyPairName
       - Label:
@@ -86,7 +86,6 @@ Metadata:
           - QSS3BucketName
           - QSS3KeyPrefix
           - ExportPrefix
-
     ParameterLabels:
       BitbucketProperties:
         default: Bitbucket properties

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -200,7 +200,7 @@ Parameters:
     Description: A space-separated list of bitbucket properties in the form 'key1=value1 key2=value2 ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
     Type: String
   BitbucketVersion:
-    Default: "6.10.0"
+    Default: "7.6.3"
     AllowedPattern: '([^1234]\.\d+\.\d+(-?.*))'
     ConstraintDescription: 'Must be a valid Bitbucket version number. For example: 5.0.0 or higher'
     Description: 'Version of Bitbucket to install. Please use version 5.0.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases'
@@ -384,11 +384,11 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 11
+    Default: 12
     AllowedValues:
-      - 10
-      - 11
       - 12
+      - 11
+      - 10
     Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Bitbucket version you're installing supports the database engine selected."
     Type: String
   DBInstanceClass:

--- a/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
+++ b/templates/quickstart-bitbucket-dc-with-vpc.template.yaml
@@ -50,6 +50,7 @@ Metadata:
       - Label:
           default: Elasticsearch
         Parameters:
+          - ElasticSearchPassword
           - ElasticsearchInstanceType
           - ElasticsearchNodeVolumeSize
       - Label:
@@ -147,6 +148,8 @@ Metadata:
         default: SSH key name to use with the repository
       CloudWatchIntegration:
         default: Enable CloudWatch integration
+      ElasticSearchPassword:
+        default: Elasticsearch master user password *
       ElasticsearchInstanceType:
         default: Elasticsearch instance type
       ElasticsearchNodeVolumeSize:
@@ -479,6 +482,10 @@ Parameters:
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Description: Database storage type
     Type: String
+  ElasticSearchPassword:
+    Description: "Password for the elasticsearch master user, the username will be 'bitbucket'. If no password is specified, Bitbucket will authenticate with the elasticsearch cluster using IAM request signing (not recommended)."
+    Type: String
+    NoEcho: True
   ElasticsearchInstanceType:
     Description: EC2 instance type for the Amazon Elasticsearch service to run on.
     Type: String
@@ -710,6 +717,7 @@ Resources:
         DeploymentAutomationKeyName: !Ref 'DeploymentAutomationKeyName'
         DeploymentAutomationCustomParams: !Ref 'DeploymentAutomationCustomParams'
         ExportPrefix: !Ref ExportPrefix
+        ElasticSearchPassword: !Ref ElasticSearchPassword
         ElasticsearchInstanceType: !Ref 'ElasticsearchInstanceType'
         ElasticsearchNodeVolumeSize: !Ref 'ElasticsearchNodeVolumeSize'
         ESBucketName: !Ref 'ESBucketName'

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -814,10 +814,10 @@ Resources:
           PropagateAtLaunch: true
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: b28727c73b0b431a7e4489a161c703fc3f3c6b7d"
+          Value: "COMMIT: 0bf6c6529a5a50615a055dcb2cb6840b519bf926"
           PropagateAtLaunch: true
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2021-02-08T08:25:12Z"
+          Value: "TIMESTAMP: 2021-02-16T00:09:16Z"
           PropagateAtLaunch: true
   ClusterNodeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -44,7 +44,7 @@ Metadata:
           - DBStorageType
       - Label:
           default: Bastion host utilization
-          Parameters:
+        Parameters:
             - BastionHostRequired
             - KeyPairName
       - Label:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -2,6 +2,8 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: "Atlassian Bitbucket Data Center (qs-1qup6ra1t)"
 Metadata:
+  QuickStartDocumentation:
+    EntrypointName: "Launch into an existing VPC"
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -182,7 +182,7 @@ Parameters:
     Description: A space-separated list of bitbucket properties in the form 'key1=value1 key2=value2 ...' Find documentation at https://confluence.atlassian.com/x/m5ZKLg
     Type: String
   BitbucketVersion:
-    Default: "6.10.0"
+    Default: "7.6.3"
     AllowedPattern: '([^1234]\.\d+\.\d+(-?.*))'
     ConstraintDescription: 'Must be a valid Bitbucket version number. For example: 5.0.0 or higher'
     Description: 'Version of Bitbucket to install. Please use version 5.0.0 or higher. Find valid versions at http://go.atlassian.com/bbs-releases'
@@ -358,11 +358,11 @@ Parameters:
     ConstraintDescription: Must be 'Amazon Aurora PostgreSQL' or 'PostgreSQL'.
     Type: String
   DBEngineVersion:
-    Default: 11
+    Default: 12
     AllowedValues:
-      - 10
-      - 11
       - 12
+      - 11
+      - 10
     Description: "The database engine version to use; we'll install a suitable minor version for your chosen engine. Make sure that the Bitbucket version you're installing supports the database engine selected."
     Type: String
   DBInstanceClass:
@@ -814,10 +814,10 @@ Resources:
           PropagateAtLaunch: true
         # NOTE: The leading COMMIT/TIMESTAMP are used to locate the position to update; see scripts/update-tags.py
         - Key: "atl:quickstart:commit-id"
-          Value: "COMMIT: e32a5cf84d397eb727e320df4c650c5f43976025"
+          Value: "COMMIT: b28727c73b0b431a7e4489a161c703fc3f3c6b7d"
           PropagateAtLaunch: true
         - Key: "atl:quickstart:timestamp"
-          Value: "TIMESTAMP: 2020-08-18T11:20:07Z"
+          Value: "TIMESTAMP: 2021-02-08T08:25:12Z"
           PropagateAtLaunch: true
   ClusterNodeLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration

--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -50,6 +50,7 @@ Metadata:
       - Label:
           default: Elasticsearch
         Parameters:
+          - ElasticSearchPassword
           - ElasticsearchInstanceType
           - ElasticsearchNodeVolumeSize
       - Label:
@@ -137,6 +138,8 @@ Metadata:
         default: SSH key name to use with the repository
       CloudWatchIntegration:
         default: Enable CloudWatch integration
+      ElasticSearchPassword:
+        default: Elasticsearch master user password *
       ElasticsearchInstanceType:
         default: Elasticsearch instance type
       ElasticsearchNodeVolumeSize:
@@ -453,6 +456,10 @@ Parameters:
     ConstraintDescription: Must be 'General Purpose (SSD)' or 'Provisioned IOPS'.
     Description: Database storage type
     Type: String
+  ElasticSearchPassword:
+    Description: "Password for the elasticsearch master user, the username will be 'bitbucket'. If no password is specified, Bitbucket will authenticate with the elasticsearch cluster using IAM request signing (not recommended)."
+    Type: String
+    NoEcho: True
   ElasticsearchInstanceType:
     Description: EC2 instance type for the Amazon Elasticsearch service to run on.
     Type: String
@@ -601,6 +608,10 @@ Conditions:
     !Not [!Equals [!Ref CloudWatchIntegration, 'Off']]
   EnableCloudWatchLogs:
     !Equals [!Ref CloudWatchIntegration, 'Metrics and Logs']
+  UseFineGrainedAccessControlES:
+    !Not [!Equals [!Ref ElasticSearchPassword, '']]
+  UseIAMSignedRequestsES:
+    !Equals [!Ref ElasticSearchPassword, '']
   RestoreFromEBSSnapshot:
     !Not [!Equals [!Ref HomeVolumeSnapshotId, '']]
   RestoreFromRDSSnapshot:
@@ -875,8 +886,11 @@ Resources:
                   - !Sub ["ATL_NFS_DISK_VOLUME_TYPE=${VolType}", VolType: !If [IsHomeProvisionedIops, "io1", "gp2"]]
                   - !Sub ["ATL_NFS_DISK_VOLUME_IOPS=${VolIOPs}", VolIOPs: !If [IsHomeProvisionedIops, !Ref "HomeIops", ""]]
                   - ""
-                  - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
-                  - !Sub ["ATL_ELASTICSEARCH_ENDPOINT=http://${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
+                  - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !If [UseFineGrainedAccessControlES, !GetAtt ElasticsearchSecure.DomainEndpoint, !GetAtt Elasticsearch.DomainEndpoint]]
+                  - !Sub ["ATL_ELASTICSEARCH_PROTOCOL=${ESScheme}", ESScheme: !If [UseFineGrainedAccessControlES, "https", "http"]]
+                  - !If [UseFineGrainedAccessControlES, "ATL_ELASTICSEARCH_USERNAME=bitbucket", !Ref "AWS::NoValue"]
+                  - !If [UseFineGrainedAccessControlES, !Sub ["ATL_ELASTICSEARCH_PASSWORD=${ESPassword}", ESPassword: !Ref ElasticSearchPassword], !Ref "AWS::NoValue"]
+                  - ""
                   - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Ref BitbucketProperties]
                   - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]
 
@@ -1012,6 +1026,7 @@ Resources:
           Value: !Ref ClusterNodeGroup
       ComparisonOperator: LessThanThreshold
   Elasticsearch:
+    Condition: UseIAMSignedRequestsES
     Type: AWS::Elasticsearch::Domain
     Properties:
       EBSOptions:
@@ -1034,6 +1049,73 @@ Resources:
           Value: !Sub "${AWS::StackName} Bitbucket Elasticsearch cluster"
         - Key: Application
           Value: !Ref "AWS::StackId"
+  ElasticsearchSecure:
+    Condition: UseFineGrainedAccessControlES
+    Type: AWS::Elasticsearch::Domain
+    Properties:
+      EBSOptions:
+        EBSEnabled: true
+        VolumeSize: !Ref ElasticsearchNodeVolumeSize
+        VolumeType: gp2
+      ElasticsearchVersion: "6.8"
+      ElasticsearchClusterConfig:
+        InstanceType: !Ref ElasticsearchInstanceType
+      AccessPolicies:
+        Version: 2012-10-17
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: "*"
+            Action: "es:ESHttp*"
+            Resource: "*"
+      AdvancedSecurityOptions:
+        Enabled: true
+        InternalUserDatabaseEnabled: true
+        MasterUserOptions:
+          MasterUserName: bitbucket
+          MasterUserPassword: !Ref ElasticSearchPassword
+      DomainEndpointOptions:
+        EnforceHTTPS: true
+        TLSSecurityPolicy: Policy-Min-TLS-1-2-2019-07
+      EncryptionAtRestOptions:
+        Enabled: true
+        KmsKeyId: !Ref ElasticsearchKMSKey
+      NodeToNodeEncryptionOptions:
+        Enabled: true
+      VPCOptions:
+        SubnetIds:
+          - !Select
+            - 0
+            - !Split
+              - ','
+              - Fn::ImportValue: !Sub '${ExportPrefix}PriNets'
+        SecurityGroupIds:
+          - !Ref SecurityGroup
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName} Bitbucket Elasticsearch cluster"
+        - Key: Application
+          Value: !Ref "AWS::StackId"
+  ElasticsearchKMSKey:
+    Condition: UseFineGrainedAccessControlES
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Encryption key for Elasticsearch cluster
+      Enabled: true
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: !Sub "${AWS::StackName}"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
+            Action: 'kms:*'
+            Resource: '*'
+      Tags:
+        - Key: Name
+          Value: !Sub ["${StackName} Elasticsearch Encryption Key", StackName: !Ref 'AWS::StackName']
   ElasticsearchBucket:
     Type: AWS::S3::Bucket
     Condition: CreateESBucket
@@ -1088,7 +1170,7 @@ Resources:
                   - !Sub ["ATL_NFS_DISK_VOLUME_TYPE=${VolType}", VolType: !If [IsHomeProvisionedIops, "io1", "gp2"]]
                   - !Sub ["ATL_NFS_DISK_VOLUME_IOPS=${VolIOPs}", VolIOPs: !If [IsHomeProvisionedIops, !Ref "HomeIops", ""]]
                   - ""
-                  - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !GetAtt Elasticsearch.DomainEndpoint]
+                  - !Sub ["ATL_ELASTICSEARCH_HOST=${ESEndpoint}", ESEndpoint: !If [UseFineGrainedAccessControlES, !GetAtt ElasticsearchSecure.DomainEndpoint, !GetAtt Elasticsearch.DomainEndpoint]]
                   - !Sub ["ATL_ELASTICSEARCH_S3_BUCKET=${BucketName}", BucketName: !Ref ESBucketName]
                   - !Sub ["ATL_BITBUCKET_PROPERTIES=\"${BitbucketProperties}\"", BitbucketProperties: !Ref BitbucketProperties]
                   - !If [DoSSL, "ATL_SSL_PROXY=true", !Ref "AWS::NoValue"]


### PR DESCRIPTION
* Update default Postgres version to 12
* Update Postgres patch versions for all supported Postgres engines
* Allow support for more secure elasticsearch
  * Deploy within VPC
  * Use fine-grained access controls
  * Encryption at rest
  * Enforce HTTPS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
