### PR TITLE
DCD-956 Fix cfn-signal in AutoScaling LaunchConfiguration

### DIFF
--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -920,6 +920,10 @@ Resources:
       Roles: [!Ref BitbucketClusterNodeRole]
   ClusterNodeGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
+    CreationPolicy:
+      ResourceSignal:
+        Count: !Ref ClusterNodeMin
+        Timeout: PT15M
     Properties:
       DesiredCapacity: !If [StandbyMode, '0', !Ref ClusterNodeMin]
       LaunchConfigurationName: !Ref ClusterNodeLaunchConfig


### PR DESCRIPTION
*DCD-956*

*Creation policy to wait until all the instances are up and running.*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.