### PR TITLE
CLIP-1750 Change installing of git packages in Bitbucket CFT

### DIFF
--- a/templates/quickstart-bitbucket-dc.template.yaml
+++ b/templates/quickstart-bitbucket-dc.template.yaml
@@ -1022,9 +1022,53 @@ Resources:
                 #!/bin/bash
                 key_location=/root/.ssh/deployment_repo_key
                 key_name="${DeploymentAutomationKeyName}"
+                bitbucket_version="${BitbucketVersion}"
                 ssm_pin=/${AWS::StackName}/pinned-ansible-sha
+                bitbucket_minor_version=$(echo "$bitbucket_version" | cut -d. -f-2)
 
-                yum install -y git awscli jq
+                case "$bitbucket_minor_version" in
+                  6.0)  supported_git_version="2.17.2" ;;
+                  6.1)  supported_git_version="2.17.2" ;;
+                  6.1)  supported_git_version="2.17.2" ;;
+                  6.2)  supported_git_version="2.17.2" ;;
+                  6.3)  supported_git_version="2.17.2" ;;
+                  6.4)  supported_git_version="2.17.2" ;;
+                  6.5)  supported_git_version="2.17.2" ;;
+                  6.6)  supported_git_version="2.23.1" ;;
+                  6.7)  supported_git_version="2.23.4" ;;
+                  6.8)  supported_git_version="2.23.4" ;;
+                  6.9)  supported_git_version="2.23.4" ;;
+                  6.10) supported_git_version="2.23.4" ;;
+                  7.0)  supported_git_version="2.23.4" ;;
+                  7.1)  supported_git_version="2.23.4" ;;
+                  7.2)  supported_git_version="2.23.4" ;;
+                  7.3)  supported_git_version="2.23.4" ;;
+                  7.4)  supported_git_version="2.23.4" ;;
+                  7.5)  supported_git_version="2.23.4" ;;
+                  7.6)  supported_git_version="2.23.4" ;;
+                  7.7)  supported_git_version="2.23.4" ;;
+                  7.8)  supported_git_version="2.23.4" ;;
+                  7.9)  supported_git_version="2.23.4" ;;
+                  7.10) supported_git_version="2.23.4" ;;
+                  7.11) supported_git_version="2.23.4" ;;
+                  7.12) supported_git_version="2.23.4" ;;
+                  7.13) supported_git_version="2.23.4" ;;
+                  7.14) supported_git_version="2.32.0" ;;
+                  7.15) supported_git_version="2.32.0" ;;
+                  7.16) supported_git_version="2.32.0" ;;
+                  7.17) supported_git_version="2.32.0" ;;
+                  7.18) supported_git_version="2.32.0" ;;
+                  7.19) supported_git_version="2.34.3" ;;
+                  7.20) supported_git_version="2.34.3" ;;
+                  7.21) supported_git_version="2.34.3" ;;
+                  8.0)  supported_git_version="2.34.3" ;;
+                  8.1)  supported_git_version="2.34.3" ;;
+                  8.2)  supported_git_version="2.34.3" ;;
+                  8.3)  supported_git_version="2.37.1" ;;
+                    *)  supported_git_version="2.37.1" ;;
+                esac
+
+                yum install -y git-"$supported_git_version" awscli jq
 
                 if [[ ! -z "$key_name" ]]; then
                     # Ensure awscli is up to date
@@ -1061,7 +1105,7 @@ Resources:
               command: mkdir -p /opt/atlassian
               ignoreErrors: false
             071_install_packages:
-              command: yum install -y git python-virtualenv
+              command: yum install -y python-virtualenv
               ignoreErrors: true
             072_clone_atl_scripts:
               test: "test ! -d /opt/atlassian/dc-deployments-automation/"
@@ -1448,8 +1492,52 @@ Resources:
                 key_location=/root/.ssh/deployment_repo_key
                 key_name="${DeploymentAutomationKeyName}"
                 ssm_pin=/${AWS::StackName}/pinned-ansible-sha
+                bitbucket_version="${BitbucketVersion}"
+                bitbucket_minor_version=$(echo "$bitbucket_version" | cut -d. -f-2)
 
-                yum install -y git awscli jq
+                case "$bitbucket_minor_version" in
+                  6.0)  supported_git_version="2.17.2" ;;
+                  6.1)  supported_git_version="2.17.2" ;;
+                  6.1)  supported_git_version="2.17.2" ;;
+                  6.2)  supported_git_version="2.17.2" ;;
+                  6.3)  supported_git_version="2.17.2" ;;
+                  6.4)  supported_git_version="2.17.2" ;;
+                  6.5)  supported_git_version="2.17.2" ;;
+                  6.6)  supported_git_version="2.23.1" ;;
+                  6.7)  supported_git_version="2.23.4" ;;
+                  6.8)  supported_git_version="2.23.4" ;;
+                  6.9)  supported_git_version="2.23.4" ;;
+                  6.10) supported_git_version="2.23.4" ;;
+                  7.0)  supported_git_version="2.23.4" ;;
+                  7.1)  supported_git_version="2.23.4" ;;
+                  7.2)  supported_git_version="2.23.4" ;;
+                  7.3)  supported_git_version="2.23.4" ;;
+                  7.4)  supported_git_version="2.23.4" ;;
+                  7.5)  supported_git_version="2.23.4" ;;
+                  7.6)  supported_git_version="2.23.4" ;;
+                  7.7)  supported_git_version="2.23.4" ;;
+                  7.8)  supported_git_version="2.23.4" ;;
+                  7.9)  supported_git_version="2.23.4" ;;
+                  7.10) supported_git_version="2.23.4" ;;
+                  7.11) supported_git_version="2.23.4" ;;
+                  7.12) supported_git_version="2.23.4" ;;
+                  7.13) supported_git_version="2.23.4" ;;
+                  7.14) supported_git_version="2.32.0" ;;
+                  7.15) supported_git_version="2.32.0" ;;
+                  7.16) supported_git_version="2.32.0" ;;
+                  7.17) supported_git_version="2.32.0" ;;
+                  7.18) supported_git_version="2.32.0" ;;
+                  7.19) supported_git_version="2.34.3" ;;
+                  7.20) supported_git_version="2.34.3" ;;
+                  7.21) supported_git_version="2.34.3" ;;
+                  8.0)  supported_git_version="2.34.3" ;;
+                  8.1)  supported_git_version="2.34.3" ;;
+                  8.2)  supported_git_version="2.34.3" ;;
+                  8.3)  supported_git_version="2.37.1" ;;
+                    *)  supported_git_version="2.37.1" ;;
+                esac
+
+                yum install -y git-"$supported_git_version" awscli jq
 
                 if [[ ! -z "$key_name" ]]; then
                     # Ensure awscli is up to date
@@ -1486,7 +1574,7 @@ Resources:
               command: mkdir -p /opt/atlassian
               ignoreErrors: false
             071_install_packages:
-              command: yum install -y git python-virtualenv
+              command: yum install -y python-virtualenv
               ignoreErrors: true
             072_clone_atl_scripts:
               test: "test ! -d /opt/atlassian/dc-deployments-automation/"


### PR DESCRIPTION
*CLIP-1750*

* CLIP-1750 Changed the way of installing git packages in BB CFT, for fixing the bug with incompatibility versions of git and BB

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.